### PR TITLE
Sikre bedre mot duplikat kall til ferdigstill

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/bestilling/BrevbestillingRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/bestilling/BrevbestillingRepository.kt
@@ -24,6 +24,8 @@ interface BrevbestillingRepository {
 
     fun hent(unikReferanse: UnikReferanse): Brevbestilling?
 
+    fun hentForOppdatering(referanse: BrevbestillingReferanse): Brevbestilling
+
     fun oppdaterBrev(
         referanse: BrevbestillingReferanse,
         brev: Brev,

--- a/app/src/main/kotlin/no/nav/aap/brev/bestilling/BrevbestillingRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/bestilling/BrevbestillingRepositoryImpl.kt
@@ -90,6 +90,17 @@ class BrevbestillingRepositoryImpl(private val connection: DBConnection) : Brevb
         }
     }
 
+    override fun hentForOppdatering(referanse: BrevbestillingReferanse): Brevbestilling {
+        return connection.queryFirst(
+            "SELECT * FROM BREVBESTILLING WHERE REFERANSE = ? FOR UPDATE"
+        ) {
+            setParams {
+                setUUID(1, referanse.referanse)
+            }
+            setRowMapper { row -> mapBestilling(row) }
+        }
+    }
+
     private fun mapBestilling(row: Row): Brevbestilling {
         val id = BrevbestillingId(row.getLong("ID"))
 

--- a/app/src/test/kotlin/no/nav/aap/brev/bestilling/BrevbestillingRepositoryImplTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/bestilling/BrevbestillingRepositoryImplTest.kt
@@ -128,6 +128,10 @@ class BrevbestillingRepositoryImplTest {
             assertEquals(distribusjonBestillingId, bestilling.distribusjonBestillingId)
 
             assertEquals(bestilling, brevbestillingRepository.hent(unikReferanse))
+            assertEquals(
+                brevbestillingRepository.hent(bestilling.referanse),
+                brevbestillingRepository.hentForOppdatering(bestilling.referanse)
+            )
         }
     }
 }

--- a/lib-test/src/main/kotlin/no/nav/aap/brev/test/Random.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/brev/test/Random.kt
@@ -8,6 +8,7 @@ import no.nav.aap.brev.journalføring.DokumentInfoId
 import no.nav.aap.brev.journalføring.JournalpostId
 import no.nav.aap.brev.kontrakt.Brevtype
 import no.nav.aap.brev.kontrakt.Språk
+import no.nav.aap.brev.prosessering.ProsesseringStatus
 import java.util.UUID
 import kotlin.random.Random
 import kotlin.random.nextInt
@@ -45,4 +46,8 @@ fun randomBrevtype(): Brevtype {
 
 fun randomSpråk(): Språk {
     return Språk.entries.random()
+}
+
+fun randomProsesseringStatus(): ProsesseringStatus {
+    return ProsesseringStatus.entries.random()
 }


### PR DESCRIPTION
Låser bestillingen ved ferdigstilling for å unngå dobbel ferdigstilling som vil kunne medføre duplikate signaturer og mottakere. Bruk Status i stede for ProsesseringStatus for å avgjøre om en bestilling er ferdigstilt.