### PR TITLE
Ikke lagre prosesseringStatus før ferdigstill

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
@@ -24,12 +24,9 @@ fun Brevbestilling.tilResponse(): BrevbestillingResponse =
 fun utledStatus(prosesseringStatus: ProsesseringStatus?): Status =
     when (prosesseringStatus) {
         null,
-        ProsesseringStatus.STARTET,
-        ProsesseringStatus.INNHOLD_HENTET,
-        ProsesseringStatus.FAKTAGRUNNLAG_HENTET -> Status.REGISTRERT
-
         ProsesseringStatus.BREVBESTILLING_LØST -> Status.UNDER_ARBEID
 
+        ProsesseringStatus.STARTET,
         ProsesseringStatus.BREV_FERDIGSTILT,
         ProsesseringStatus.JOURNALFORT,
         ProsesseringStatus.JOURNALPOST_VEDLEGG_TILKNYTTET,

--- a/app/src/main/kotlin/no/nav/aap/brev/prosessering/ProsesseringStatus.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/prosessering/ProsesseringStatus.kt
@@ -2,8 +2,6 @@ package no.nav.aap.brev.prosessering
 
 enum class ProsesseringStatus {
     STARTET,
-    INNHOLD_HENTET,
-    FAKTAGRUNNLAG_HENTET,
     BREVBESTILLING_LØST,
     BREV_FERDIGSTILT,
     JOURNALFORT,

--- a/app/src/test/kotlin/no/nav/aap/brev/bestilling/AvbrytValideringTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/bestilling/AvbrytValideringTest.kt
@@ -1,80 +1,50 @@
 package no.nav.aap.brev.bestilling
 
+import no.nav.aap.brev.IntegrationTest
 import no.nav.aap.brev.exception.ValideringsfeilException
 import no.nav.aap.brev.kontrakt.Status
-import no.nav.aap.brev.no.nav.aap.brev.test.Fakes
 import no.nav.aap.brev.prosessering.ProsesseringStatus
-import no.nav.aap.brev.test.randomBehandlingReferanse
-import no.nav.aap.brev.test.randomBrevtype
-import no.nav.aap.brev.test.randomBrukerIdent
-import no.nav.aap.brev.test.randomSaksnummer
-import no.nav.aap.brev.test.randomSpråk
-import no.nav.aap.brev.test.randomUnikReferanse
 import no.nav.aap.komponenter.dbconnect.transaction
-import no.nav.aap.komponenter.dbtest.InitTestDatabase
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.EnumSource.Mode
 
-class AvbrytValideringTest {
-
-    companion object {
-
-        private val dataSource = InitTestDatabase.freshDatabase()
-
-        @BeforeAll
-        @JvmStatic
-        fun beforeAll() {
-            Fakes.start()
-        }
-    }
+class AvbrytValideringTest : IntegrationTest() {
 
     @Test
     fun `avbryt går igjennom fra gydlig status`() {
         val referanse =
-            gittBrevMed(status = Status.UNDER_ARBEID, prosesseringStatus = ProsesseringStatus.BREVBESTILLING_LØST)
+            gittBrevMed(status = Status.UNDER_ARBEID)
         avbryt(referanse)
         assertStatus(referanse, Status.AVBRUTT, ProsesseringStatus.AVBRUTT)
     }
 
     @ParameterizedTest
-    @EnumSource(ProsesseringStatus::class, mode = Mode.EXCLUDE, names = ["BREVBESTILLING_LØST"])
-    fun `avbryt feiler fra andre statuser enn BREVBESTILLING_LØST`(status: ProsesseringStatus) {
-        val referanse = gittBrevMed(status = Status.FERDIGSTILT, prosesseringStatus = status)
+    @EnumSource(Status::class, mode = Mode.EXCLUDE, names = ["UNDER_ARBEID"])
+    fun `avbryt feiler fra andre statuser enn UNDER_ARBEID`(status: Status) {
+        val referanse = gittBrevMed(status = status)
         val exception = assertThrows<ValideringsfeilException> {
             avbryt(referanse)
         }
         assertThat(exception.message).endsWith(
             "Kan ikke avbryte brevbestilling med status $status"
         )
-        assertStatus(referanse, Status.FERDIGSTILT, status)
+        assertStatus(referanse, status, null)
     }
 
     private fun gittBrevMed(
         status: Status,
-        prosesseringStatus: ProsesseringStatus
     ): BrevbestillingReferanse {
         return dataSource.transaction { connection ->
-            val brevbestillingService = BrevbestillingService.konstruer(connection)
             val brevbestillingRepository = BrevbestillingRepositoryImpl(connection)
 
-            val bestilling = brevbestillingService.opprettBestillingV2(
-                saksnummer = randomSaksnummer(),
-                brukerIdent = randomBrukerIdent(),
-                behandlingReferanse = randomBehandlingReferanse(),
-                unikReferanse = randomUnikReferanse(),
-                brevtype = randomBrevtype(),
-                språk = randomSpråk(),
-                faktagrunnlag = emptySet(),
-                vedlegg = emptySet(),
+            val bestilling = opprettBrevbestilling(
                 ferdigstillAutomatisk = false,
             ).brevbestilling
 
-            brevbestillingRepository.oppdaterProsesseringStatus(bestilling.referanse, prosesseringStatus)
             brevbestillingRepository.oppdaterStatus(bestilling.id, status)
 
             bestilling.referanse
@@ -90,7 +60,7 @@ class AvbrytValideringTest {
     private fun assertStatus(
         referanse: BrevbestillingReferanse,
         forventetStatus: Status,
-        forventetProsesseringStatus: ProsesseringStatus
+        forventetProsesseringStatus: ProsesseringStatus?
     ) {
         return dataSource.transaction { connection ->
             val brevbestillingService = BrevbestillingService.konstruer(connection)

--- a/app/src/test/kotlin/no/nav/aap/brev/bestilling/BrevbestillingRepositoryImplTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/bestilling/BrevbestillingRepositoryImplTest.kt
@@ -87,11 +87,11 @@ class BrevbestillingRepositoryImplTest {
 
             brevbestillingRepository.oppdaterProsesseringStatus(
                 bestilling.referanse,
-                ProsesseringStatus.FAKTAGRUNNLAG_HENTET
+                ProsesseringStatus.STARTET
             )
             bestilling = brevbestillingRepository.hent(bestilling.referanse)
 
-            assertEquals(ProsesseringStatus.FAKTAGRUNNLAG_HENTET, bestilling.prosesseringStatus)
+            assertEquals(ProsesseringStatus.STARTET, bestilling.prosesseringStatus)
 
             brevbestillingRepository.lagreSignaturer(bestilling.id, signaturer)
             bestilling = brevbestillingRepository.hent(bestilling.referanse)

--- a/app/src/test/kotlin/no/nav/aap/brev/bestilling/BrevbestillingTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/bestilling/BrevbestillingTest.kt
@@ -6,7 +6,6 @@ import no.nav.aap.brev.innhold.harFaktagrunnlag
 import no.nav.aap.brev.kontrakt.Brevtype
 import no.nav.aap.brev.kontrakt.Faktagrunnlag
 import no.nav.aap.brev.kontrakt.Status
-import no.nav.aap.brev.prosessering.ProsesseringStatus
 import no.nav.aap.brev.test.randomUnikReferanse
 import no.nav.aap.komponenter.dbconnect.transaction
 import org.assertj.core.api.Assertions.assertThat
@@ -21,7 +20,6 @@ class BrevbestillingTest : IntegrationTest() {
         val resultat = opprettBrevbestilling(ferdigstillAutomatisk = false)
         assertThat(resultat.brevbestilling.brev).isNotNull
         assertThat(resultat.brevbestilling.status).isEqualTo(Status.UNDER_ARBEID)
-        assertThat(resultat.brevbestilling.prosesseringStatus).isEqualTo(ProsesseringStatus.BREVBESTILLING_LØST)
         assertAntallJobber(resultat.brevbestilling.referanse, 0)
         assertThat(resultat.alleredeOpprettet).isFalse
     }
@@ -37,7 +35,6 @@ class BrevbestillingTest : IntegrationTest() {
         assertThat(resultat.brevbestilling.brev).isNotNull
         assertThat(resultat.brevbestilling.brev?.harFaktagrunnlag()).isFalse
         assertThat(resultat.brevbestilling.status).isEqualTo(Status.UNDER_ARBEID)
-        assertThat(resultat.brevbestilling.prosesseringStatus).isEqualTo(ProsesseringStatus.BREVBESTILLING_LØST)
         assertAntallJobber(resultat.brevbestilling.referanse, 0)
         assertThat(resultat.alleredeOpprettet).isFalse
     }
@@ -50,7 +47,6 @@ class BrevbestillingTest : IntegrationTest() {
         )
 
         assertThat(resultat.brevbestilling.status).isEqualTo(Status.FERDIGSTILT)
-        assertThat(resultat.brevbestilling.prosesseringStatus).isEqualTo(ProsesseringStatus.BREVBESTILLING_LØST)
         assertAntallJobber(resultat.brevbestilling.referanse, 1)
         dataSource.transaction { connection ->
             val mottakerRepository = MottakerRepositoryImpl(connection)
@@ -71,7 +67,6 @@ class BrevbestillingTest : IntegrationTest() {
         )
 
         assertThat(resultat.brevbestilling.status).isEqualTo(Status.UNDER_ARBEID)
-        assertThat(resultat.brevbestilling.prosesseringStatus).isEqualTo(ProsesseringStatus.BREVBESTILLING_LØST)
         assertAntallJobber(resultat.brevbestilling.referanse, 0)
     }
 

--- a/app/src/test/kotlin/no/nav/aap/brev/prosessering/ProsesserStegServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/prosessering/ProsesserStegServiceTest.kt
@@ -74,10 +74,7 @@ class ProsesserStegServiceTest : IntegrationTest() {
                 ferdigstillAutomatisk = false
             ).brevbestilling.referanse
 
-            assertEquals(
-                ProsesseringStatus.BREVBESTILLING_LØST,
-                brevbestillingService.hent(referanse).prosesseringStatus
-            )
+            assertNull(brevbestillingService.hent(referanse).prosesseringStatus)
             assertEquals(
                 Status.UNDER_ARBEID,
                 brevbestillingService.hent(referanse).status
@@ -86,12 +83,20 @@ class ProsesserStegServiceTest : IntegrationTest() {
             brevbestillingService.avbryt(referanse)
 
             assertEquals(
+                Status.AVBRUTT,
+                brevbestillingService.hent(referanse).status
+            )
+            assertEquals(
                 ProsesseringStatus.AVBRUTT,
                 brevbestillingService.hent(referanse).prosesseringStatus
             )
 
             prosesserStegService.prosesserBestilling(referanse)
 
+            assertEquals(
+                Status.AVBRUTT,
+                brevbestillingService.hent(referanse).status
+            )
             assertEquals(
                 ProsesseringStatus.AVBRUTT,
                 brevbestillingService.hent(referanse).prosesseringStatus

--- a/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/Status.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/Status.kt
@@ -2,26 +2,20 @@ package no.nav.aap.brev.kontrakt
 
 enum class Status {
     /**
-     * Brevbestillingen er mottatt og registrert. Ikke relevant for V2 API
-     */
-    REGISTRERT,
-
-    /**
      * Initiell prosessering, som å hente data fra Sanity,
      * er utført, og brevet kan redigeres av saksbehandler.
      */
     UNDER_ARBEID,
 
     /**
-     * Brevet er ferdig redigert av saksbehandler og kan
-     * journalføres og distribueres. Eventuelt har bestillingen
-     * gått direkte til denne statusen eller fra status `REGISTRERT`,
-     * dersom det ikke er behov for manuell redigering av saksbehandler.
+     * Brevet er ferdigstilt enten ved manuell ferdigstilling, eller
+     * automatisk, spesifisert i bestillingen. Brevet er eller vil bli
+     * journalført og distribuert automatisk i denne statusen.
      */
     FERDIGSTILT,
 
     /**
-     * Brevbestillingen er manuelt avbrutt
+     * Brevbestillingen er manuelt avbrutt.
      */
     AVBRUTT,
 }


### PR DESCRIPTION
Alle stegene i prosesseringen skjer nå etter ferdigstill, i motsetning til før da noen steg ble uført ved bestilling. Tidligere utførte steg ved bestilling er fjernet, fjerner derfor nå lagring av prosesseringStatus ved bestilling (da man skal starte fra begynnelsen når man ferdigstiller). Dette endrer også litt på validering for /ferdigstill og /avbryt, som nå sjekker på Status.UNDER_ARBEID. Fjerner ubrukt Status.REGISTRERT, ProsesseringStatus.INNHOLD_HENTET, ProsesseringStatus.FAKTAGRUNNLAG_HENTET, og tilpasser mapping fra ProsesseringStatus til Status. ProsesseringStatus.BREVBESTILLING_LØST henger igjen for bakoverkompabilitet.