### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -125,6 +125,8 @@ spec:
 
     - name: INTEGRASJON_DOKDISTFORDELING_URL
       value: https://dokdistfordeling.dev-fss-pub.nais.io
+    - name: INTEGRASJON_DOKDISTFORDELING_SCOPE
+      value: api://dev-fss.teamdokumenthandtering.dokdistfordeling/.default
 
     - name: INTEGRASJON_SAF_URL_GRAPHQL
       value: https://saf-q2.dev-fss-pub.nais.io/graphql

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -115,6 +115,8 @@ spec:
 
     - name: INTEGRASJON_DOKDISTFORDELING_URL
       value: https://dokdistfordeling.prod-fss-pub.nais.io
+    - name: INTEGRASJON_DOKDISTFORDELING_SCOPE
+      value: api://prod-fss.teamdokumenthandtering.dokdistfordeling/.default
 
     - name: INTEGRASJON_SAF_URL_GRAPHQL
       value: https://saf.prod-fss-pub.nais.io/graphql

--- a/.run/dev-gcp.run.xml
+++ b/.run/dev-gcp.run.xml
@@ -18,6 +18,7 @@
       <env name="INTEGRASJON_DOKARKIV_URL" value="https://dokarkiv-q2.dev-fss-pub.nais.io" />
       <env name="INTEGRASJON_DOKARKIV_SCOPE" value="api://dev-fss.teamdokumenthandtering.dokarkiv/.default" />
       <env name="INTEGRASJON_DOKDISTFORDELING_URL" value="https://dokdistfordeling.dev-fss-pub.nais.io" />
+      <env name="INTEGRASJON_DOKDISTFORDELING_SCOPE" value="api://dev-fss.teamdokumenthandtering.dokdistfordeling/.default" />
       <env name="INTEGRASJON_SAF_URL_GRAPHQL" value="https://saf-q2.dev-fss-pub.nais.io/graphql" />
       <env name="INTEGRASJON_SAF_SCOPE" value="api://dev-fss.teamdokumenthandtering.saf/.default" />
       <env name="INTEGRASJON_NOM_URL" value="https://nom-api.intern.dev.nav.no/graphql" />

--- a/app/src/main/kotlin/no/nav/aap/brev/distribusjon/DokdistfordelingGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/distribusjon/DokdistfordelingGateway.kt
@@ -17,7 +17,7 @@ import java.net.URI
 
 class DokdistfordelingGateway : DistribusjonGateway {
     private val baseUri = URI.create(requiredConfigForKey("integrasjon.dokdistfordeling.url"))
-    val config = ClientConfig(scope = requiredConfigForKey("integrasjon.saf.scope"))
+    val config = ClientConfig(scope = requiredConfigForKey("integrasjon.dokdistfordeling.scope"))
     private val client = RestClient(
         config = config,
         tokenProvider = ClientCredentialsTokenProvider,

--- a/lib-test/src/main/kotlin/no/nav/aap/brev/test/Fakes.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/brev/test/Fakes.kt
@@ -77,6 +77,7 @@ object Fakes : AutoCloseable {
 
         // Dokdistfordeling
         System.setProperty("integrasjon.dokdistfordeling.url", "http://localhost:${dokdistfordeling.port()}")
+        System.setProperty("integrasjon.dokdistfordeling.scope", "scope")
 
         // Norg
         System.setProperty("integrasjon.norg.url", "http://localhost:${norg.port()}")


### PR DESCRIPTION
* La til ENV `INTEGRASJON_DOKDISTFORDELING_SCOPE` med dokdistfordeling-scope
* Endret `DokdistfordelingGateway` til å bruke dokdistfordeling-scope

> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.

Har dobbeltsjekket dokdistfordeling config og `prod-gcp:aap:brev` ligger inne i dokdistfordeling sin preauthorized liste. Så dere skal ikke merke noe. 🙇