### PR TITLE
Ny flyt for bestilling og oppdatering med ny brevmodell

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
@@ -1,13 +1,16 @@
 package no.nav.aap.brev.api
 
 import no.nav.aap.brev.bestilling.Brevbestilling
+import no.nav.aap.brev.bestilling.Brevdata
 import no.nav.aap.brev.bestilling.IdentType
 import no.nav.aap.brev.bestilling.Mottaker
 import no.nav.aap.brev.kontrakt.BrevbestillingResponse
 import no.nav.aap.brev.kontrakt.MottakerDto
+import no.nav.aap.brev.kontrakt.OppdaterBrevdataRequest
 import no.nav.aap.brev.kontrakt.Status
 import no.nav.aap.brev.prosessering.ProsesseringStatus
-import java.util.*
+import no.nav.aap.komponenter.json.DefaultJsonMapper
+import java.util.UUID
 
 fun Brevbestilling.tilResponse(): BrevbestillingResponse =
     BrevbestillingResponse(
@@ -62,5 +65,42 @@ internal fun List<MottakerDto>.tilMottakere(bestillingReferanse: UUID) = this.ma
     mottaker.tilMottaker(
         bestillingReferanse = bestillingReferanse,
         index = index
+    )
+}
+
+fun OppdaterBrevdataRequest.tilBrevdata(): Brevdata {
+    return Brevdata(
+        delmaler = delmaler.map { delmal -> Brevdata.Delmal(id = delmal.id) },
+        faktagrunnlag = faktagrunnlag.map { faktagrunnlagMedVerdi ->
+            Brevdata.FaktagrunnlagMedVerdi(
+                tekniskNavn = faktagrunnlagMedVerdi.tekniskNavn,
+                verdi = faktagrunnlagMedVerdi.verdi
+            )
+        },
+        periodetekster = periodetekster.map { periodetekst ->
+            Brevdata.Periodetekst(
+                id = periodetekst.id,
+                faktagrunnlagMedVerdi = periodetekst.faktagrunnlagMedVerdi.map { faktagrunnlagMedVerdi ->
+                    Brevdata.FaktagrunnlagMedVerdi(
+                        tekniskNavn = faktagrunnlagMedVerdi.tekniskNavn,
+                        verdi = faktagrunnlagMedVerdi.verdi
+                    )
+                }
+            )
+        },
+        valg = valg.map { valg ->
+            Brevdata.Valg(
+                valg.id,
+                valg.valgt,
+                valg.fritekstJson?.let { fritekst -> DefaultJsonMapper.fromJson(fritekst) },
+            )
+        },
+        betingetTekst = betingetTekst.map { tekst -> Brevdata.BetingetTekst(tekst.id) },
+        fritekster = fritekster.map { fritekst ->
+            Brevdata.FritekstMedKey(
+                fritekst.key,
+                DefaultJsonMapper.fromJson(fritekst.fritekstJson)
+            )
+        },
     )
 }

--- a/app/src/main/kotlin/no/nav/aap/brev/bestilling/Brevbestilling.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/bestilling/Brevbestilling.kt
@@ -25,4 +25,8 @@ data class Brevbestilling(
     val status: Status?,
     val prosesseringStatus: ProsesseringStatus?,
     val vedlegg: Set<Vedlegg>,
-)
+) {
+    fun erBestillingMedBrevmal(): Boolean {
+        return brev == null && brevmal != null && brevdata != null
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/brev/journalføring/JournalføringService.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/journalføring/JournalføringService.kt
@@ -55,8 +55,27 @@ class JournalføringService(
 
         val pdf = pdfService.genererPdfForJournalføring(bestilling, personinfo)
 
+        val tittelBrev = if (bestilling.erBestillingMedBrevmal()) {
+            checkNotNull(bestilling.brevmal?.tilBrevmal()?.overskrift)
+        } else {
+            checkNotNull(bestilling.brev?.overskrift)
+        }
+
+        val tittelJournalpost = if (bestilling.erBestillingMedBrevmal()) {
+            bestilling.brevmal?.tilBrevmal()?.journalposttittel
+        } else {
+            bestilling.brev?.journalpostTittel
+        } ?: tittelBrev
+
         mottakere.forEach { mottaker ->
-            journalførBrevbestilling(bestilling, mottaker, personinfo, pdf)
+            journalførBrevbestilling(
+                bestilling = bestilling,
+                mottaker = mottaker,
+                personinfo = personinfo,
+                pdf = pdf,
+                tittelJournalpost = tittelJournalpost,
+                tittelBrev = tittelBrev
+            )
         }
     }
 
@@ -64,11 +83,10 @@ class JournalføringService(
         bestilling: Brevbestilling,
         mottaker: Mottaker,
         personinfo: Personinfo,
-        pdf: Pdf
+        pdf: Pdf,
+        tittelJournalpost: String,
+        tittelBrev: String,
     ) {
-        checkNotNull(bestilling.brev) {
-            "Kan ikke journalføre bestilling uten brev."
-        }
         requireNotNull(mottaker.id) {
             "Mottaker må være lagret i databasen før journalføring"
         }
@@ -84,8 +102,8 @@ class JournalføringService(
             mottakerNavn = mottaker.navnOgAdresse?.navn,
             saksnummer = bestilling.saksnummer,
             eksternReferanseId = mottaker.bestillingMottakerReferanse,
-            tittelJournalpost = checkNotNull(value = bestilling.brev.journalpostTittel ?: bestilling.brev.overskrift),
-            tittelBrev = checkNotNull(value = bestilling.brev.overskrift),
+            tittelJournalpost = tittelJournalpost,
+            tittelBrev = tittelBrev,
             brevkode = bestilling.brevtype.name,
             overstyrInnsynsregel = false,
         )

--- a/app/src/test/kotlin/no/nav/aap/brev/IntegrationTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/IntegrationTest.kt
@@ -42,6 +42,7 @@ abstract class IntegrationTest {
     }
 
     fun opprettBrevbestilling(
+        brukV3: Boolean = false,
         saksnummer: Saksnummer = randomSaksnummer(),
         brukerIdent: String = randomBrukerIdent(),
         behandlingReferanse: BehandlingReferanse = randomBehandlingReferanse(),
@@ -54,17 +55,32 @@ abstract class IntegrationTest {
     ): OpprettBrevbestillingResultat {
         return dataSource.transaction { connection ->
             val brevbestillingService = BrevbestillingService.konstruer(connection)
-            brevbestillingService.opprettBestillingV2(
-                saksnummer = saksnummer,
-                brukerIdent = brukerIdent,
-                behandlingReferanse = behandlingReferanse,
-                unikReferanse = unikReferanse,
-                brevtype = brevtype,
-                språk = språk,
-                faktagrunnlag = faktagrunnlag,
-                vedlegg = vedlegg,
-                ferdigstillAutomatisk = ferdigstillAutomatisk,
-            )
+            if (brukV3) {
+                brevbestillingService.opprettBestillingV3(
+                    saksnummer = saksnummer,
+                    brukerIdent = brukerIdent,
+                    behandlingReferanse = behandlingReferanse,
+                    unikReferanse = unikReferanse,
+                    brevtype = brevtype,
+                    språk = språk,
+                    faktagrunnlag = faktagrunnlag,
+                    vedlegg = vedlegg,
+                    ferdigstillAutomatisk = ferdigstillAutomatisk,
+                )
+            } else {
+                brevbestillingService.opprettBestillingV2(
+                    saksnummer = saksnummer,
+                    brukerIdent = brukerIdent,
+                    behandlingReferanse = behandlingReferanse,
+                    unikReferanse = unikReferanse,
+                    brevtype = brevtype,
+                    språk = språk,
+                    faktagrunnlag = faktagrunnlag,
+                    vedlegg = vedlegg,
+                    ferdigstillAutomatisk = ferdigstillAutomatisk,
+                )
+
+            }
         }
     }
 

--- a/app/src/test/kotlin/no/nav/aap/brev/bestilling/BestillingValideringTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/bestilling/BestillingValideringTest.kt
@@ -1,10 +1,10 @@
 package no.nav.aap.brev.bestilling
 
+import no.nav.aap.brev.IntegrationTest
 import no.nav.aap.brev.arkivoppslag.Journalpost
 import no.nav.aap.brev.feil.ValideringsfeilException
 import no.nav.aap.brev.kontrakt.Brevtype
 import no.nav.aap.brev.kontrakt.Språk
-import no.nav.aap.brev.no.nav.aap.brev.test.Fakes
 import no.nav.aap.brev.test.fakes.gittJournalpostIArkivet
 import no.nav.aap.brev.test.randomBehandlingReferanse
 import no.nav.aap.brev.test.randomBrukerIdent
@@ -13,27 +13,17 @@ import no.nav.aap.brev.test.randomJournalpostId
 import no.nav.aap.brev.test.randomSaksnummer
 import no.nav.aap.brev.test.randomUnikReferanse
 import no.nav.aap.komponenter.dbconnect.transaction
-import no.nav.aap.komponenter.dbtest.InitTestDatabase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
-class BestillingValideringTest {
+class BestillingValideringTest : IntegrationTest() {
 
-    companion object {
-        private val dataSource = InitTestDatabase.freshDatabase()
-
-        @BeforeAll
-        @JvmStatic
-        fun beforeAll() {
-            Fakes.start()
-        }
-    }
-
-    @Test
-    fun `bestilling går igjennom dersom ingen valideringsfeil`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `bestilling går igjennom dersom ingen valideringsfeil`(brukV3: Boolean) {
         val saksnummer = randomSaksnummer()
         val brukerIdent = randomBrukerIdent()
         val dokumentInfoId = randomDokumentInfoId()
@@ -42,11 +32,9 @@ class BestillingValideringTest {
             saksnummer = saksnummer,
             dokumentInfoId = dokumentInfoId
         )
-        dataSource.transaction { connection ->
-            val brevbestillingService = BrevbestillingService.konstruer(connection)
-            val brevbestillingRepository = BrevbestillingRepositoryImpl(connection)
-
-            val referanse = brevbestillingService.opprettBestillingV2(
+        val referanse =
+            opprettBrevbestilling(
+                brukV3 = brukV3,
                 saksnummer = saksnummer,
                 brukerIdent = brukerIdent,
                 behandlingReferanse = randomBehandlingReferanse(),
@@ -57,12 +45,17 @@ class BestillingValideringTest {
                 vedlegg = setOf(Vedlegg(journalpost.journalpostId, dokumentInfoId)),
                 ferdigstillAutomatisk = false,
             ).brevbestilling.referanse
+
+        dataSource.transaction { connection ->
+            val brevbestillingRepository = BrevbestillingRepositoryImpl(connection)
+
             assertNotNull(brevbestillingRepository.hent(referanse))
         }
     }
 
-    @Test
-    fun `validering feiler dersom sak på vedlegg ikke har fagsakId lik bestillingens saksnummer`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `validering feiler dersom sak på vedlegg ikke har fagsakId lik bestillingens saksnummer`(brukV3: Boolean) {
         val dokumentInfoId = randomDokumentInfoId()
         val journalpost = gittJournalpostIArkivet(
             journalpostId = randomJournalpostId(),
@@ -71,14 +64,16 @@ class BestillingValideringTest {
         )
 
         validerFeilVedBestilling(
+            brukV3 = brukV3,
             saksnummer = randomSaksnummer(),
             vedlegg = journalpost.somVedlegg(),
             feilmelding = "Ulik sak."
         )
     }
 
-    @Test
-    fun `validering feiler dersom sak på vedlegg ikke har fagsystem KELVIN`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `validering feiler dersom sak på vedlegg ikke har fagsystem KELVIN`(brukV3: Boolean) {
         val saksnummer = randomSaksnummer()
         val dokumentInfoId = randomDokumentInfoId()
         val journalpost = gittJournalpostIArkivet(
@@ -89,14 +84,16 @@ class BestillingValideringTest {
         )
 
         validerFeilVedBestilling(
+            brukV3 = brukV3,
             saksnummer = saksnummer,
             vedlegg = journalpost.somVedlegg(),
             feilmelding = "Ulik sak."
         )
     }
 
-    @Test
-    fun `validering feiler dersom sak på vedlegg ikke er sakstype FAGSAK`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `validering feiler dersom sak på vedlegg ikke er sakstype FAGSAK`(brukV3: Boolean) {
         val saksnummer = randomSaksnummer()
         val dokumentInfoId = randomDokumentInfoId()
         val journalpost = gittJournalpostIArkivet(
@@ -107,14 +104,16 @@ class BestillingValideringTest {
         )
 
         validerFeilVedBestilling(
+            brukV3 = brukV3,
             saksnummer = saksnummer,
             vedlegg = journalpost.somVedlegg(),
             feilmelding = "Ulik sak."
         )
     }
 
-    @Test
-    fun `validering feiler dersom sak på vedlegg ikke har tema AAP`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `validering feiler dersom sak på vedlegg ikke har tema AAP`(brukV3: Boolean) {
         val saksnummer = randomSaksnummer()
         val dokumentInfoId = randomDokumentInfoId()
         val journalpost = gittJournalpostIArkivet(
@@ -125,14 +124,16 @@ class BestillingValideringTest {
         )
 
         validerFeilVedBestilling(
+            brukV3 = brukV3,
             saksnummer = saksnummer,
             vedlegg = journalpost.somVedlegg(),
             feilmelding = "Ulik sak."
         )
     }
 
-    @Test
-    fun `validering feiler dersom vedlegg ikke journalstatus FERDIGSTILT, EKSPEDERT eller FEILREGISTRERT`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `validering feiler dersom vedlegg ikke journalstatus FERDIGSTILT, EKSPEDERT eller FEILREGISTRERT`(brukV3: Boolean) {
         val saksnummer = randomSaksnummer()
         val dokumentInfoId = randomDokumentInfoId()
         val journalpost = gittJournalpostIArkivet(
@@ -143,14 +144,16 @@ class BestillingValideringTest {
         )
 
         validerFeilVedBestilling(
+            brukV3 = brukV3,
             saksnummer = saksnummer,
             vedlegg = journalpost.somVedlegg(),
             feilmelding = "Feil status JOURNALFOERT."
         )
     }
 
-    @Test
-    fun `validering feiler dersom vedlegg ikke har dokumentet i arkivet`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `validering feiler dersom vedlegg ikke har dokumentet i arkivet`(brukV3: Boolean) {
         val saksnummer = randomSaksnummer()
         val journalpost = gittJournalpostIArkivet(
             journalpostId = randomJournalpostId(),
@@ -159,6 +162,7 @@ class BestillingValideringTest {
         )
 
         validerFeilVedBestilling(
+            brukV3 = brukV3,
             saksnummer = saksnummer,
             vedlegg = setOf(Vedlegg(journalpost.journalpostId, randomDokumentInfoId())),
             feilmelding = "Fant ikke dokument i journalpost."
@@ -170,14 +174,15 @@ class BestillingValideringTest {
     }
 
     private fun validerFeilVedBestilling(
+        brukV3: Boolean,
         saksnummer: Saksnummer,
         vedlegg: Set<Vedlegg>,
         feilmelding: String,
     ) {
         dataSource.transaction { connection ->
-            val brevbestillingService = BrevbestillingService.konstruer(connection)
             val exception = assertThrows<ValideringsfeilException> {
-                brevbestillingService.opprettBestillingV2(
+                opprettBrevbestilling(
+                    brukV3 = brukV3,
                     saksnummer = saksnummer,
                     brukerIdent = randomBrukerIdent(),
                     behandlingReferanse = randomBehandlingReferanse(),

--- a/app/src/test/kotlin/no/nav/aap/brev/bestilling/BrevbestillingTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/bestilling/BrevbestillingTest.kt
@@ -11,22 +11,39 @@ import no.nav.aap.komponenter.dbconnect.transaction
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import java.time.LocalDate
+import kotlin.booleanArrayOf
 
 class BrevbestillingTest : IntegrationTest() {
 
     @Test
-    fun `oppretter bestilling`() {
-        val resultat = opprettBrevbestilling(ferdigstillAutomatisk = false)
+    fun `oppretter bestilling v2`() {
+        val resultat = opprettBrevbestilling(brukV3 = false, ferdigstillAutomatisk = false)
         assertThat(resultat.brevbestilling.brev).isNotNull
+        assertThat(resultat.brevbestilling.brevmal).isNull()
+        assertThat(resultat.brevbestilling.brevdata).isNull()
         assertThat(resultat.brevbestilling.status).isEqualTo(Status.UNDER_ARBEID)
         assertAntallJobber(resultat.brevbestilling.referanse, 0)
         assertThat(resultat.alleredeOpprettet).isFalse
     }
 
     @Test
-    fun `oppretter bestilling, henter innhold, fyller inn faktagrunnlag og oppdaterer status`() {
+    fun `oppretter bestilling v3`() {
+        val resultat = opprettBrevbestilling(brukV3 = true, ferdigstillAutomatisk = false)
+        assertThat(resultat.brevbestilling.brev).isNull()
+        assertThat(resultat.brevbestilling.brevmal).isNotNull
+        assertThat(resultat.brevbestilling.brevdata).isNotNull
+        assertThat(resultat.brevbestilling.status).isEqualTo(Status.UNDER_ARBEID)
+        assertAntallJobber(resultat.brevbestilling.referanse, 0)
+        assertThat(resultat.alleredeOpprettet).isFalse
+    }
+
+    @Test
+    fun `oppretter bestilling, henter innhold, fyller inn faktagrunnlag og oppdaterer status v2`() {
         val resultat = opprettBrevbestilling(
+            brukV3 = false,
             brevtype = Brevtype.FORHÅNDSVARSEL_BRUDD_AKTIVITETSPLIKT,
             ferdigstillAutomatisk = false,
             faktagrunnlag = setOf(Faktagrunnlag.FristDato11_7(frist = LocalDate.now())),
@@ -40,10 +57,30 @@ class BrevbestillingTest : IntegrationTest() {
     }
 
     @Test
-    fun `setter status ferdigstilt og legger til jobb for automatisk ferdigstilling dersom brev kan sendes automatisk`() {
+    fun `oppretter bestilling, henter innhold, lagrer initielle brevdata og oppdaterer status v3`() {
         val resultat = opprettBrevbestilling(
+            brukV3 = true,
+            brevtype = Brevtype.FORHÅNDSVARSEL_BRUDD_AKTIVITETSPLIKT,
+            ferdigstillAutomatisk = false,
+            faktagrunnlag = setOf(Faktagrunnlag.FristDato11_7(frist = LocalDate.now())),
+        )
+
+        assertThat(resultat.brevbestilling.brevmal).isNotNull
+        assertThat(resultat.brevbestilling.brevdata).isNotNull
+        assertThat(resultat.brevbestilling.status).isEqualTo(Status.UNDER_ARBEID)
+        assertAntallJobber(resultat.brevbestilling.referanse, 0)
+        assertThat(resultat.alleredeOpprettet).isFalse
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `setter status ferdigstilt og legger til jobb for automatisk ferdigstilling dersom brev kan sendes automatisk`(
+        brukV3: Boolean
+    ) {
+        val resultat = opprettBrevbestilling(
+            brukV3 = brukV3,
             brevtype = Brevtype.VARSEL_OM_BESTILLING,
-            ferdigstillAutomatisk = true,
+            ferdigstillAutomatisk = true
         )
 
         assertThat(resultat.brevbestilling.status).isEqualTo(Status.FERDIGSTILT)
@@ -59,9 +96,11 @@ class BrevbestillingTest : IntegrationTest() {
         }
     }
 
-    @Test
-    fun `ferdigstiller ikke ved bestilling som ikke skal ferdigstilles automatisk`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `ferdigstiller ikke ved bestilling som ikke skal ferdigstilles automatisk`(brukV3: Boolean) {
         val resultat = opprettBrevbestilling(
+            brukV3 = brukV3,
             brevtype = Brevtype.VARSEL_OM_BESTILLING,
             ferdigstillAutomatisk = false,
         )
@@ -71,10 +110,11 @@ class BrevbestillingTest : IntegrationTest() {
     }
 
     @Test
-    fun `feiler ved bestilling som skal ferdigstilles automatisk dersom brevet ikke kan sendes automatisk`() {
+    fun `feiler ved bestilling som skal ferdigstilles automatisk dersom brevet ikke kan sendes automatisk v2`() {
         val unikReferanse: UnikReferanse = randomUnikReferanse()
         val exception = assertThrows<ValideringsfeilException> {
             opprettBrevbestilling(
+                brukV3 = false,
                 brevtype = Brevtype.FORHÅNDSVARSEL_BRUDD_AKTIVITETSPLIKT,
                 ferdigstillAutomatisk = true,
                 faktagrunnlag = setOf(Faktagrunnlag.FristDato11_7(frist = LocalDate.now())),
@@ -91,6 +131,27 @@ class BrevbestillingTest : IntegrationTest() {
     }
 
     @Test
+    fun `feiler ved bestilling som skal ferdigstilles automatisk dersom brevet ikke kan sendes automatisk v3`() {
+        val unikReferanse: UnikReferanse = randomUnikReferanse()
+        val exception = assertThrows<ValideringsfeilException> {
+            opprettBrevbestilling(
+                brukV3 = true,
+                brevtype = Brevtype.FORHÅNDSVARSEL_BRUDD_AKTIVITETSPLIKT,
+                ferdigstillAutomatisk = true,
+                faktagrunnlag = setOf(Faktagrunnlag.FristDato11_7(frist = LocalDate.now())),
+                unikReferanse = unikReferanse,
+            )
+        }
+        assertThat(exception.message).isEqualTo(
+            "Kan ikke automatisk ferdigstille brevbestilling: Brevmal er ikke konfigurert til at brevet kan sendes automatisk."
+        )
+        dataSource.transaction { connection ->
+            val bestilling = BrevbestillingRepositoryImpl(connection).hent(unikReferanse)
+            assertThat(bestilling).isNull()
+        }
+    }
+
+    @Test // Kan slettes med v2, dekkes av BrevbyggerServiceTest
     fun `feiler ved bestilling som skal ferdigstilles automatisk dersom brevet kan sendes automatisk men har faktagrunnlag`() {
         val exception = assertThrows<ValideringsfeilException> {
             opprettBrevbestilling(
@@ -104,7 +165,7 @@ class BrevbestillingTest : IntegrationTest() {
         )
     }
 
-    @Test
+    @Test // Kan slettes med v2, dekkes av BrevbyggerServiceTest
     fun `feiler ved bestilling som skal ferdigstilles automatisk dersom brevet kan sendes automatisk men er ikke fullstendig`() {
         val exception = assertThrows<ValideringsfeilException> {
             opprettBrevbestilling(
@@ -118,7 +179,7 @@ class BrevbestillingTest : IntegrationTest() {
         )
     }
 
-    @Test
+    @Test // Kan slettes med v2, dekkes av BrevbyggerServiceTest
     fun `feiler ved bestilling som skal ferdigstilles automatisk dersom brevet kan sendes automatisk men innhold kan redigeres`() {
         val exception = assertThrows<ValideringsfeilException> {
             opprettBrevbestilling(
@@ -132,11 +193,16 @@ class BrevbestillingTest : IntegrationTest() {
         )
     }
 
-    @Test
-    fun `gjør ingenting dersom bestillingen allerede er opprettet`() {
-        val resultat1 = opprettBrevbestilling(ferdigstillAutomatisk = false)
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `gjør ingenting dersom bestillingen allerede er opprettet`(brukV3: Boolean) {
+        val resultat1 = opprettBrevbestilling(
+            brukV3 = brukV3,
+            ferdigstillAutomatisk = false
+        )
 
         val resultat2 = opprettBrevbestilling(
+            brukV3 = brukV3,
             saksnummer = resultat1.brevbestilling.saksnummer,
             brukerIdent = checkNotNull(resultat1.brevbestilling.brukerIdent),
             behandlingReferanse = resultat1.brevbestilling.behandlingReferanse,

--- a/app/src/test/kotlin/no/nav/aap/brev/journalføring/JournalføringServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/journalføring/JournalføringServiceTest.kt
@@ -4,6 +4,9 @@ import no.nav.aap.brev.IntegrationTest
 import no.nav.aap.brev.bestilling.Adresse
 import no.nav.aap.brev.bestilling.Brevbestilling
 import no.nav.aap.brev.bestilling.BrevbestillingService
+import no.nav.aap.brev.bestilling.Brevdata
+import no.nav.aap.brev.bestilling.Brevdata.FaktagrunnlagMedVerdi
+import no.nav.aap.brev.bestilling.Brevdata.FritekstMedKey
 import no.nav.aap.brev.bestilling.IdentType
 import no.nav.aap.brev.bestilling.JournalpostRepositoryImpl
 import no.nav.aap.brev.bestilling.Mottaker
@@ -14,15 +17,19 @@ import no.nav.aap.brev.test.fakes.journalpostForBestilling
 import no.nav.aap.brev.test.randomBehandlingReferanse
 import no.nav.aap.brev.test.randomJournalpostId
 import no.nav.aap.komponenter.dbconnect.transaction
+import no.nav.aap.komponenter.json.DefaultJsonMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.booleanArrayOf
 
 class JournalføringServiceTest : IntegrationTest() {
 
-    @Test
-    fun `journalfører brevet og lagrer journalpostId`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `journalfører brevet og lagrer journalpostId`(brukV3: Boolean) {
         dataSource.transaction { connection ->
             val brevbestillingService = BrevbestillingService.konstruer(connection)
             val journalføringService = JournalføringService.konstruer(connection)
@@ -31,6 +38,7 @@ class JournalføringServiceTest : IntegrationTest() {
             val journalpostRepository = JournalpostRepositoryImpl(connection)
 
             val bestilling = opprettBrevbestilling(
+                brukV3 = brukV3,
                 behandlingReferanse = behandlingReferanse,
                 brevtype = Brevtype.INNVILGELSE,
                 ferdigstillAutomatisk = false,
@@ -60,6 +68,22 @@ class JournalføringServiceTest : IntegrationTest() {
                 ),
                 bestillingMottakerReferanse = bestillingMottakerReferanse2
             )
+            if (brukV3) {
+                brevbestillingService.oppdaterBrevdata(
+                    bestilling.referanse,
+                    bestilling.brevdata!!.copy(
+                        faktagrunnlag = bestilling.brevdata.faktagrunnlag
+                            .plus(FaktagrunnlagMedVerdi("VAR_1", ""))
+                            .plus(FaktagrunnlagMedVerdi("VAR_2", "")),
+                        fritekster = bestilling.brevdata.fritekster.plus(
+                            FritekstMedKey(
+                                "8a3109fb503c",
+                                Brevdata.Fritekst(DefaultJsonMapper.fromJson("""{"fritekst": "abc"}"""))
+                            )
+                        )
+                    )
+                )
+            }
             brevbestillingService.ferdigstill(bestilling.referanse, emptyList(), listOf(mottaker1, mottaker2))
 
             journalføringService.journalførBrevbestilling(bestilling.referanse)
@@ -75,13 +99,15 @@ class JournalføringServiceTest : IntegrationTest() {
         }
     }
 
-    @Test
-    fun `validering feiler dersom bestillingen mangler brev`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `validering feiler dersom bestillingen mangler brev`(brukV3: Boolean) {
         dataSource.transaction { connection ->
             val journalføringService = JournalføringService.konstruer(connection)
             val mottakerRepository = MottakerRepositoryImpl(connection)
 
             val bestilling = opprettBrevbestilling(
+                brukV3 = brukV3,
                 brevtype = Brevtype.INNVILGELSE,
                 ferdigstillAutomatisk = false,
             ).brevbestilling
@@ -93,11 +119,12 @@ class JournalføringServiceTest : IntegrationTest() {
             )
 
             connection.execute(
-                "UPDATE BREVBESTILLING SET BREV = ?::jsonb WHERE REFERANSE = ?"
+                "UPDATE BREVBESTILLING SET BREV = ?::jsonb, BREVMAL = ?::jsonb WHERE REFERANSE = ?"
             ) {
                 setParams {
                     setString(1, null)
-                    setUUID(2, referanse.referanse)
+                    setString(2, null)
+                    setUUID(3, referanse.referanse)
                 }
             }
 
@@ -108,32 +135,9 @@ class JournalføringServiceTest : IntegrationTest() {
         }
     }
 
-    @Test
-    fun `validering feiler dersom brevet inneholder manglende faktagrunnlag`() {
-        dataSource.transaction { connection ->
-            val journalføringService = JournalføringService.konstruer(connection)
-            val mottakerRepository = MottakerRepositoryImpl(connection)
-
-            val bestilling = opprettBrevbestilling(
-                brevtype = Brevtype.FORHÅNDSVARSEL_BRUDD_AKTIVITETSPLIKT,
-                ferdigstillAutomatisk = false,
-            ).brevbestilling
-            mottakerRepository.lagreMottakere(
-                bestilling.id,
-                mottakereLikBrukerIdent(bestilling, "${bestilling.referanse.referanse}-1")
-            )
-            val referanse = bestilling.referanse
-            val exception = assertThrows<IllegalStateException> {
-                journalføringService.journalførBrevbestilling(
-                    referanse,
-                )
-            }
-            assertEquals(exception.message, "Kan ikke lage PDF av brev med manglende faktagrunnlag FRIST_DATO_11_7.")
-        }
-    }
-
-    @Test
-    fun `håndterer respons med http status 409 pga allerede journalført`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `håndterer respons med http status 409 pga allerede journalført`(brukV3: Boolean) {
         dataSource.transaction { connection ->
             val journalføringService = JournalføringService.konstruer(connection)
             val behandlingReferanse = randomBehandlingReferanse()
@@ -141,6 +145,7 @@ class JournalføringServiceTest : IntegrationTest() {
             val journalpostRepository = JournalpostRepositoryImpl(connection)
 
             val bestilling = opprettBrevbestilling(
+                brukV3 = brukV3,
                 behandlingReferanse = behandlingReferanse,
                 brevtype = Brevtype.INNVILGELSE,
                 ferdigstillAutomatisk = false,

--- a/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/OppdaterBrevdataRequest.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/OppdaterBrevdataRequest.kt
@@ -1,0 +1,32 @@
+package no.nav.aap.brev.kontrakt
+
+data class OppdaterBrevdataRequest(
+    val delmaler: List<Delmal>,
+    val faktagrunnlag: List<FaktagrunnlagMedVerdi>,
+    val periodetekster: List<Periodetekst>,
+    val valg: List<Valg>,
+    val betingetTekst: List<BetingetTekst>,
+    val fritekster: List<FritekstMedKey>
+) {
+    data class Delmal(val id: String)
+
+    data class FaktagrunnlagMedVerdi(
+        val tekniskNavn: String,
+        val verdi: String
+    )
+
+    data class Periodetekst(
+        val id: String,
+        val faktagrunnlagMedVerdi: List<FaktagrunnlagMedVerdi>
+    )
+
+    data class Valg(
+        val id: String,
+        val valgt: String, // key
+        val fritekstJson: String?,
+    )
+
+    data class FritekstMedKey(val key: String, val fritekstJson: String)
+
+    data class BetingetTekst(val id: String)
+}

--- a/lib-test/src/main/kotlin/no/nav/aap/brev/test/FileUtils.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/brev/test/FileUtils.kt
@@ -2,8 +2,6 @@ package no.nav.aap.brev.test
 
 import com.fasterxml.jackson.core.JsonParser
 import no.nav.aap.komponenter.json.DefaultJsonMapper
-import kotlin.io.bufferedReader
-import kotlin.io.readText
 
 object FileUtils {
     fun lesFil(filnavn: String): String {


### PR DESCRIPTION
Nye API-endepunkter (v3) for bestilling og oppdatering. Tilpassing av funksjonalitet basert på om bestillingen er basert på ny eller gammel modell:
- Valider ferdigstilling
- Generering av PDF
- Journalføring

Tilpasser tester til å kjøre med med ny og gammel modell