### PR TITLE
fix: gradle-oppsett som i behandlingsflyt

### DIFF
--- a/buildSrc/src/main/kotlin/brev.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/brev.conventions.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+// Felles kode for alle build.gradle.kts filer som laster inn denne conventions pluginen
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
@@ -6,22 +6,6 @@ plugins {
 
 group = "no.nav.aap"
 version = project.findProperty("version")?.toString() ?: "0.0.0"
-
-repositories {
-    mavenCentral()
-    maven("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
-    maven {
-        name = "GitHubPackages"
-        url = uri("https://maven.pkg.github.com/navikt/behandlingsflyt")
-        credentials {
-            username = "x-access-token"
-            password = (project.findProperty("githubPassword")
-                ?: System.getenv("GITHUB_PASSWORD")
-                ?: System.getenv("GITHUB_TOKEN")
-                ?: error("Mangler PAT for GitHub package registry. Sett property githubPassword, eller miljøvariabelen GITHUB_TOKEN")).toString()
-        }
-    }
-}
 
 // https://docs.gradle.org/8.12.1/userguide/jvm_test_suite_plugin.html
 testing {
@@ -32,18 +16,47 @@ testing {
     }
 }
 
-tasks.test {
-    useJUnitPlatform()
-    maxParallelForks = Runtime.getRuntime().availableProcessors()
+tasks {
+    test {
+        useJUnitPlatform()
+        maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+        testLogging {
+            events("passed", "skipped", "failed")
+        }
+    }
+
+    (findByName("distTar") as? Tar)?.apply {
+        // Bruk et unikt navn for jar-filen til distTar, for å unngå navnekollisjoner i multi-modul prosjekt,
+        // slik at vi ikke bruker samme navn, feks. "kontrakt.jar" "api.jar" i flere moduler.
+        // Dette unngår feil av typen "Entry <name>.jar is a duplicate but no duplicate handling strategy has been set"
+        // Alternativet er å unngå å bruke det eksakt samme navnet på moduler i forskjellige prosjekter, som feks "kontrakt".
+        archiveBaseName.set("${rootProject.name}-${project.name}")
+    }
 }
 
 kotlin {
     jvmToolchain(21)
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_21)
-        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
+
+        // Bruk et unikt navn for <project>.kotlin_module for hvert sub-prosjekt,
+        // slik at vi unngår navnekollisjoner når vi inkluderer flere av våre kotlin-moduler i samme jar-fil, feks. ved bruk av shadowJar.
+        // Kroneksempelet er "kontrakt.kotlin_module" fra både behandlingsflyt, brev, meldekort og andre steder.
+        // Dette gjør at vi kan beholde informasjonen for hver modul, og kotlin-reflect og andre verktøy fungerer som forventet.
+        // Alternativet er å unngå å bruke det eksakt samme navnet på moduler i forskjellige prosjekter, som feks "kontrakt".
+        freeCompilerArgs.add("-module-name=${rootProject.name}-${project.name}")
     }
 }
+
+// Pass på at når vi kaller JavaExec eller Test tasks så bruker vi samme språk-versjon som vi kompilerer til
+val toolchainLauncher = javaToolchains.launcherFor {
+    languageVersion.set(JavaLanguageVersion.of(21))
+}
+tasks.withType<Test>().configureEach { javaLauncher.set(toolchainLauncher) }
+tasks.withType<JavaExec>().configureEach { javaLauncher.set(toolchainLauncher) }
+
 
 kotlin.sourceSets["main"].kotlin.srcDirs("main")
 kotlin.sourceSets["test"].kotlin.srcDirs("test")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,3 +6,27 @@ include(
     "kontrakt",
     "lib-test",
 )
+
+
+val githubPassword: String? by settings
+
+dependencyResolutionManagement {
+    // Felles for alle gradle prosjekter i repoet
+    @Suppress("UnstableApiUsage")
+    repositories {
+        maven("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
+        mavenCentral()
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/navikt/behandlingsflyt")
+            credentials {
+                username = "x-access-token"
+                password = (githubPassword
+                    ?: System.getenv("GITHUB_PASSWORD")
+                    ?: System.getenv("GITHUB_TOKEN")
+                    ?: error("GITHUB_TOKEN not set"))
+            }
+        }
+        mavenLocal()
+    }
+}


### PR DESCRIPTION
Følg samme mønster som behandlingsflyt i de andre appene som publiserer jar-filer

AAP-1627