### PR TITLE
Forbedre struktur på brevdata

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
@@ -99,7 +99,7 @@ fun OppdaterBrevdataRequest.tilBrevdata(): Brevdata {
             Brevdata.Fritekst(
                 parentId = fritekst.parentId,
                 key = fritekst.key,
-                fritekst = DefaultJsonMapper.fromJson(fritekst.fritekstJson)
+                fritekst = DefaultJsonMapper.fromJson(fritekst.fritekst)
             )
         },
     )

--- a/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
@@ -71,7 +71,7 @@ internal fun List<MottakerDto>.tilMottakere(bestillingReferanse: UUID) = this.ma
 fun OppdaterBrevdataRequest.tilBrevdata(): Brevdata {
     return Brevdata(
         delmaler = delmaler.map { delmal -> Brevdata.Delmal(id = delmal.id) },
-        faktagrunnlag = this@tilBrevdata.faktagrunnlag.map { faktagrunnlagMedVerdi ->
+        faktagrunnlag = faktagrunnlag.map { faktagrunnlagMedVerdi ->
             Brevdata.Faktagrunnlag(
                 tekniskNavn = faktagrunnlagMedVerdi.tekniskNavn,
                 verdi = faktagrunnlagMedVerdi.verdi

--- a/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
@@ -71,8 +71,8 @@ internal fun List<MottakerDto>.tilMottakere(bestillingReferanse: UUID) = this.ma
 fun OppdaterBrevdataRequest.tilBrevdata(): Brevdata {
     return Brevdata(
         delmaler = delmaler.map { delmal -> Brevdata.Delmal(id = delmal.id) },
-        faktagrunnlag = faktagrunnlag.map { faktagrunnlagMedVerdi ->
-            Brevdata.FaktagrunnlagMedVerdi(
+        faktagrunnlag = this@tilBrevdata.faktagrunnlag.map { faktagrunnlagMedVerdi ->
+            Brevdata.Faktagrunnlag(
                 tekniskNavn = faktagrunnlagMedVerdi.tekniskNavn,
                 verdi = faktagrunnlagMedVerdi.verdi
             )
@@ -80,8 +80,8 @@ fun OppdaterBrevdataRequest.tilBrevdata(): Brevdata {
         periodetekster = periodetekster.map { periodetekst ->
             Brevdata.Periodetekst(
                 id = periodetekst.id,
-                faktagrunnlagMedVerdi = periodetekst.faktagrunnlagMedVerdi.map { faktagrunnlagMedVerdi ->
-                    Brevdata.FaktagrunnlagMedVerdi(
+                faktagrunnlag = periodetekst.faktagrunnlag.map { faktagrunnlagMedVerdi ->
+                    Brevdata.Faktagrunnlag(
                         tekniskNavn = faktagrunnlagMedVerdi.tekniskNavn,
                         verdi = faktagrunnlagMedVerdi.verdi
                     )
@@ -91,13 +91,13 @@ fun OppdaterBrevdataRequest.tilBrevdata(): Brevdata {
         valg = valg.map { valg ->
             Brevdata.Valg(
                 valg.id,
-                valg.valgt,
-                valg.fritekstJson?.let { fritekst -> DefaultJsonMapper.fromJson(fritekst) },
+                valg.key,
             )
         },
         betingetTekst = betingetTekst.map { tekst -> Brevdata.BetingetTekst(tekst.id) },
         fritekster = fritekster.map { fritekst ->
-            Brevdata.FritekstMedKey(
+            Brevdata.Fritekst(
+                fritekst.id,
                 fritekst.key,
                 DefaultJsonMapper.fromJson(fritekst.fritekstJson)
             )

--- a/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/api/Mappers.kt
@@ -90,16 +90,16 @@ fun OppdaterBrevdataRequest.tilBrevdata(): Brevdata {
         },
         valg = valg.map { valg ->
             Brevdata.Valg(
-                valg.id,
-                valg.key,
+                id = valg.id,
+                key = valg.key,
             )
         },
         betingetTekst = betingetTekst.map { tekst -> Brevdata.BetingetTekst(tekst.id) },
         fritekster = fritekster.map { fritekst ->
             Brevdata.Fritekst(
-                fritekst.id,
-                fritekst.key,
-                DefaultJsonMapper.fromJson(fritekst.fritekstJson)
+                parentId = fritekst.parentId,
+                key = fritekst.key,
+                fritekst = DefaultJsonMapper.fromJson(fritekst.fritekstJson)
             )
         },
     )

--- a/app/src/main/kotlin/no/nav/aap/brev/bestilling/Brevdata.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/bestilling/Brevdata.kt
@@ -4,34 +4,38 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 
 data class Brevdata(
     val delmaler: List<Delmal>,
-    val faktagrunnlag: List<FaktagrunnlagMedVerdi>,
+    val faktagrunnlag: List<Faktagrunnlag>,
     val periodetekster: List<Periodetekst>,
     val valg: List<Valg>,
     val betingetTekst: List<BetingetTekst>,
-    val fritekster: List<FritekstMedKey>
+    val fritekster: List<Fritekst>
 ) {
     data class Delmal(val id: String)
 
-    data class FaktagrunnlagMedVerdi(
+    data class Faktagrunnlag(
         val tekniskNavn: String,
         val verdi: String
     )
 
     data class Periodetekst(
         val id: String,
-        val faktagrunnlagMedVerdi: List<FaktagrunnlagMedVerdi>
+        val faktagrunnlag: List<Faktagrunnlag>
     )
 
     data class Valg(
         val id: String,
-        val valgt: String, // key
-        val fritekst: Fritekst?,
+        val key: String,
     )
 
     @JvmInline
-    value class Fritekst(val json: ObjectNode)
+    value class FritekstJson(val json: ObjectNode)
 
-    data class FritekstMedKey(val key: String, val fritekst: Fritekst)
+    // Kan være fritekst for en delmal eller valg
+    data class Fritekst(
+        val id: String,
+        val key: String,
+        val fritekst: FritekstJson
+    )
 
     data class BetingetTekst(val id: String)
 }

--- a/app/src/main/kotlin/no/nav/aap/brev/bestilling/Brevdata.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/bestilling/Brevdata.kt
@@ -32,7 +32,7 @@ data class Brevdata(
 
     // Kan være fritekst for en delmal eller valg
     data class Fritekst(
-        val id: String,
+        val parentId: String,
         val key: String,
         val fritekst: FritekstJson
     )

--- a/app/src/main/kotlin/no/nav/aap/brev/innhold/BrevbyggerService.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/innhold/BrevbyggerService.kt
@@ -1,7 +1,6 @@
 package no.nav.aap.brev.innhold
 
 import no.nav.aap.brev.bestilling.Brevdata
-import no.nav.aap.brev.bestilling.Brevdata.FaktagrunnlagMedVerdi
 import no.nav.aap.brev.bestilling.BrevbestillingReferanse
 import no.nav.aap.brev.bestilling.BrevbestillingRepository
 import no.nav.aap.brev.bestilling.BrevbestillingRepositoryImpl
@@ -62,11 +61,11 @@ class BrevbyggerService(
     private fun utledFaktagrunnlagMedVerdi(
         faktagrunnlag: Set<Faktagrunnlag>,
         språk: Språk
-    ): List<FaktagrunnlagMedVerdi> {
+    ): List<Brevdata.Faktagrunnlag> {
         val faktagrunnlagTekst = faktagrunnlagService.faktagrunnlagTilTekst(faktagrunnlag, språk)
 
         return faktagrunnlagTekst.entries.map { faktagrunnlag ->
-            FaktagrunnlagMedVerdi(
+            Brevdata.Faktagrunnlag(
                 faktagrunnlag.key.name,
                 faktagrunnlag.value
             )
@@ -100,7 +99,7 @@ class BrevbyggerService(
                             .find { valgAlternativ ->
                                 relevanteKategorier.contains(valgAlternativ.kategori?.tekniskNavn)
                             } ?: return@mapNotNull null
-                    Brevdata.Valg(id = valg.valg._id, forhåndsvalgt._key, null)
+                    Brevdata.Valg(id = valg.valg._id, forhåndsvalgt._key)
                 }
         }
     }
@@ -215,7 +214,7 @@ class BrevbyggerService(
             val faktagrunnlag = periodetekst?.periodetekst?.teksteditor?.flatMap { it.children }
                 ?.filterIsInstance<BlockChildren.Faktagrunnlag>() ?: emptyList()
             val manglendeFaktagrunnlag = faktagrunnlag.map { it.tekniskNavn }
-                .subtract(periodetekstData.faktagrunnlagMedVerdi.map { it.tekniskNavn })
+                .subtract(periodetekstData.faktagrunnlag.map { it.tekniskNavn }.toSet())
             valider(manglendeFaktagrunnlag.isEmpty()) {
                 "$feilmelding: Mangler faktagrunnlag ${manglendeFaktagrunnlag.joinToString(separator = ",")} for periodetekst."
             }
@@ -258,7 +257,7 @@ class BrevbyggerService(
                         if (valgData != null) {
                             teksteditorElement.valg.alternativer
                                 .filterIsInstance<Brevmal.ValgAlternativ.KategorisertTekst>()
-                                .find { it._key == valgData.valgt }
+                                .find { it._key == valgData.key }
                                 ?.tekst?.teksteditor
                                 ?.flatMap { filtrerFaktagrunnlag(it) } ?: emptyList()
                         } else {

--- a/app/src/test/kotlin/no/nav/aap/brev/bestilling/BrevbestillingRepositoryImplTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/bestilling/BrevbestillingRepositoryImplTest.kt
@@ -48,16 +48,15 @@ class BrevbestillingRepositoryImplTest {
             val brevdata = Brevdata(
                 delmaler = listOf(Brevdata.Delmal("1"), Brevdata.Delmal("2")),
                 faktagrunnlag = listOf(
-                    Brevdata.FaktagrunnlagMedVerdi("A", "v1"),
-                    Brevdata.FaktagrunnlagMedVerdi("B", "v2")
+                    Brevdata.Faktagrunnlag("A", "v1"),
+                    Brevdata.Faktagrunnlag("B", "v2")
                 ),
-                periodetekster = listOf(Brevdata.Periodetekst("3", listOf(Brevdata.FaktagrunnlagMedVerdi("C", "v3")))),
+                periodetekster = listOf(Brevdata.Periodetekst("3", listOf(Brevdata.Faktagrunnlag("C", "v3")))),
                 valg = listOf(
-                    Brevdata.Valg("4", "5", null),
-                    Brevdata.Valg("6", "7", DefaultJsonMapper.fromJson("""{"fritekst": "abc"}"""))
+                    Brevdata.Valg("4", "5"),
                 ),
                 betingetTekst = listOf(Brevdata.BetingetTekst("8"), Brevdata.BetingetTekst("9")),
-                fritekster = listOf(Brevdata.FritekstMedKey("10", DefaultJsonMapper.fromJson("""{"fritekst": "def"}""")))
+                fritekster = listOf(Brevdata.Fritekst("10", "11", DefaultJsonMapper.fromJson("""{"fritekst": "def"}""")))
             )
             val signaturNavIdent1 = randomNavIdent()
             val signaturNavIdent2 = randomNavIdent()

--- a/app/src/test/kotlin/no/nav/aap/brev/innhold/BrevbyggerServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/innhold/BrevbyggerServiceTest.kt
@@ -5,8 +5,6 @@ import no.nav.aap.brev.bestilling.BrevbestillingId
 import no.nav.aap.brev.bestilling.BrevbestillingReferanse
 import no.nav.aap.brev.bestilling.BrevbestillingRepositoryImpl
 import no.nav.aap.brev.bestilling.Brevdata
-import no.nav.aap.brev.bestilling.Brevdata.Delmal
-import no.nav.aap.brev.bestilling.Brevdata.FaktagrunnlagMedVerdi
 import no.nav.aap.brev.bestilling.BrevmalJson
 import no.nav.aap.brev.feil.ValideringsfeilException
 import no.nav.aap.brev.kontrakt.Brevmal
@@ -43,10 +41,10 @@ class BrevbyggerServiceTest : IntegrationTest() {
             val oppdatertBestilling = brevbestillingRepository.hent(bestilling.referanse)
 
             assertThat(oppdatertBestilling.brevdata?.delmaler)
-                .containsExactlyInAnyOrder(Delmal("49d9c7a7-29db-43c6-aece-45e97314a50a"))
+                .containsExactlyInAnyOrder(Brevdata.Delmal("49d9c7a7-29db-43c6-aece-45e97314a50a"))
 
             assertThat(oppdatertBestilling.brevdata?.faktagrunnlag).containsExactlyInAnyOrder(
-                FaktagrunnlagMedVerdi(
+                Brevdata.Faktagrunnlag(
                     FAKTAGRUNNLAG_TYPE_AAP_FOM_DATO,
                     aapFomDato.dato.formaterFullLengde(bestilling.språk)
                 )
@@ -100,12 +98,12 @@ class BrevbyggerServiceTest : IntegrationTest() {
 
                 oppdaterBrevdata(bestilling.referanse) {
                     this.copy(
-                        delmaler = listOf(Delmal(_id)),
+                        delmaler = listOf(Brevdata.Delmal(_id)),
                         faktagrunnlag = listOf(
-                            FaktagrunnlagMedVerdi(KjentFaktagrunnlag.AAP_FOM_DATO.name, "AAP_FOM_DATO"),
-                            FaktagrunnlagMedVerdi(KjentFaktagrunnlag.BEREGNINGSTIDSPUNKT.name, "BEREGNINGSTIDSPUNKT"),
-                            FaktagrunnlagMedVerdi(KjentFaktagrunnlag.BEREGNINGSGRUNNLAG.name, "BEREGNINGSGRUNNLAG"),
-                            FaktagrunnlagMedVerdi(
+                            Brevdata.Faktagrunnlag(KjentFaktagrunnlag.AAP_FOM_DATO.name, "AAP_FOM_DATO"),
+                            Brevdata.Faktagrunnlag(KjentFaktagrunnlag.BEREGNINGSTIDSPUNKT.name, "BEREGNINGSTIDSPUNKT"),
+                            Brevdata.Faktagrunnlag(KjentFaktagrunnlag.BEREGNINGSGRUNNLAG.name, "BEREGNINGSGRUNNLAG"),
+                            Brevdata.Faktagrunnlag(
                                 KjentFaktagrunnlag.GRUNNLAG_BEREGNING_AAR_1_AARSTALL.name,
                                 "GRUNNLAG_BEREGNING_AAR_1_AARSTALL"
                             )
@@ -113,22 +111,23 @@ class BrevbyggerServiceTest : IntegrationTest() {
                         periodetekster = listOf(
                             Brevdata.Periodetekst(
                                 periodetekst1.periodetekst._id, listOf(
-                                    FaktagrunnlagMedVerdi(KjentFaktagrunnlag.FRIST_DATO_11_7.name, "FRIST_DATO_11_7"),
-                                    FaktagrunnlagMedVerdi(
+                                    Brevdata.Faktagrunnlag(KjentFaktagrunnlag.FRIST_DATO_11_7.name, "FRIST_DATO_11_7"),
+                                    Brevdata.Faktagrunnlag(
                                         KjentFaktagrunnlag.BEREGNINGSGRUNNLAG.name,
                                         "BEREGNINGSGRUNNLAG"
                                     )
                                 )
                             ),
                         ),
-                        valg = listOf(Brevdata.Valg(valg1.valg._id, valg1.valg.alternativer.first()._key, null)),
+                        valg = listOf(Brevdata.Valg(valg1.valg._id, valg1.valg.alternativer.first()._key)),
                         betingetTekst = listOf(
                             Brevdata.BetingetTekst(betingetTekst1.tekst._id)
                         ),
                         fritekster = listOf(
-                            Brevdata.FritekstMedKey(
+                            Brevdata.Fritekst(
+                                _id,
                                 fritekst._key,
-                                Brevdata.Fritekst(DefaultJsonMapper.fromJson("""{"fritekst": "abc"}"""))
+                                Brevdata.FritekstJson(DefaultJsonMapper.fromJson("""{"fritekst": "abc"}"""))
                             )
                         )
                     )
@@ -155,7 +154,7 @@ class BrevbyggerServiceTest : IntegrationTest() {
                 obligatorisk = true
             }
             oppdaterBrevdata(bestilling.referanse) {
-                this.copy(delmaler = listOf(Delmal(delmal1.delmal._id)))
+                this.copy(delmaler = listOf(Brevdata.Delmal(delmal1.delmal._id)))
             }
         })
         val exception = assertThrows<ValideringsfeilException> {
@@ -178,7 +177,7 @@ class BrevbyggerServiceTest : IntegrationTest() {
                 manglendeFritekst = fritekst()
             }
             oppdaterBrevdata(bestilling.referanse) {
-                this.copy(delmaler = listOf(Delmal(delmalMedMangler.delmal._id)))
+                this.copy(delmaler = listOf(Brevdata.Delmal(delmalMedMangler.delmal._id)))
             }
         })
         val exception = assertThrows<ValideringsfeilException> {
@@ -206,12 +205,11 @@ class BrevbyggerServiceTest : IntegrationTest() {
                     betingetTekst(listOf("kategori_1", "kategori_2"), listOf(KjentFaktagrunnlag.BARNETILLEGG_SATS.name))
                 oppdaterBrevdata(bestilling.referanse) {
                     this.copy(
-                        delmaler = listOf(Delmal(_id)),
+                        delmaler = listOf(Brevdata.Delmal(_id)),
                         valg = listOf(
                             Brevdata.Valg(
                                 valg1.valg._id,
                                 valg1.valg.alternativer.first()._key,
-                                null
                             )
                         ),
                         betingetTekst = listOf(Brevdata.BetingetTekst(betingetTekst1.tekst._id))
@@ -243,7 +241,7 @@ class BrevbyggerServiceTest : IntegrationTest() {
                 }
             }
             oppdaterBrevdata(bestilling.referanse) {
-                this.copy(delmaler = listOf(Delmal(delmalMedMangler.delmal._id)))
+                this.copy(delmaler = listOf(Brevdata.Delmal(delmalMedMangler.delmal._id)))
             }
         })
         val exception = assertThrows<ValideringsfeilException> {
@@ -269,12 +267,11 @@ class BrevbyggerServiceTest : IntegrationTest() {
 
                 oppdaterBrevdata(bestilling.referanse) {
                     this.copy(
-                        delmaler = listOf(Delmal(_id)),
+                        delmaler = listOf(Brevdata.Delmal(_id)),
                         valg = listOf(
                             Brevdata.Valg(
                                 valg1.valg._id,
                                 valg1.valg.alternativer[1]._key,
-                                null
                             )
                         )
                     )
@@ -304,11 +301,11 @@ class BrevbyggerServiceTest : IntegrationTest() {
                 )
                 oppdaterBrevdata(bestilling.referanse) {
                     this.copy(
-                        delmaler = listOf(Delmal(_id)),
+                        delmaler = listOf(Brevdata.Delmal(_id)),
                         periodetekster = listOf(
                             Brevdata.Periodetekst(
                                 periodetekst1.periodetekst._id, listOf(
-                                    FaktagrunnlagMedVerdi(KjentFaktagrunnlag.FRIST_DATO_11_7.name, "FRIST_DATO_11_7")
+                                    Brevdata.Faktagrunnlag(KjentFaktagrunnlag.FRIST_DATO_11_7.name, "FRIST_DATO_11_7")
                                 )
                             ),
                         ),

--- a/app/src/test/kotlin/no/nav/aap/brev/journalføring/JournalføringServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/journalføring/JournalføringServiceTest.kt
@@ -5,8 +5,6 @@ import no.nav.aap.brev.bestilling.Adresse
 import no.nav.aap.brev.bestilling.Brevbestilling
 import no.nav.aap.brev.bestilling.BrevbestillingService
 import no.nav.aap.brev.bestilling.Brevdata
-import no.nav.aap.brev.bestilling.Brevdata.FaktagrunnlagMedVerdi
-import no.nav.aap.brev.bestilling.Brevdata.FritekstMedKey
 import no.nav.aap.brev.bestilling.IdentType
 import no.nav.aap.brev.bestilling.JournalpostRepositoryImpl
 import no.nav.aap.brev.bestilling.Mottaker
@@ -73,12 +71,13 @@ class JournalføringServiceTest : IntegrationTest() {
                     bestilling.referanse,
                     bestilling.brevdata!!.copy(
                         faktagrunnlag = bestilling.brevdata.faktagrunnlag
-                            .plus(FaktagrunnlagMedVerdi("VAR_1", ""))
-                            .plus(FaktagrunnlagMedVerdi("VAR_2", "")),
+                            .plus(Brevdata.Faktagrunnlag("VAR_1", ""))
+                            .plus(Brevdata.Faktagrunnlag("VAR_2", "")),
                         fritekster = bestilling.brevdata.fritekster.plus(
-                            FritekstMedKey(
+                            Brevdata.Fritekst(
+                                "49d9c7a7-29db-43c6-aece-45e97314a50a",
                                 "8a3109fb503c",
-                                Brevdata.Fritekst(DefaultJsonMapper.fromJson("""{"fritekst": "abc"}"""))
+                                Brevdata.FritekstJson(DefaultJsonMapper.fromJson("""{"fritekst": "abc"}"""))
                             )
                         )
                     )

--- a/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/OppdaterBrevdataRequest.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/OppdaterBrevdataRequest.kt
@@ -1,14 +1,14 @@
 package no.nav.aap.brev.kontrakt
 
 data class OppdaterBrevdataRequest(
-    val delmaler: List<ValgtDelmal>,
+    val delmaler: List<Delmal>,
     val faktagrunnlag: List<Faktagrunnlag>,
     val periodetekster: List<Periodetekst>,
     val valg: List<Valg>,
     val betingetTekst: List<BetingetTekst>,
     val fritekster: List<Fritekst>
 ) {
-    data class ValgtDelmal(val id: String)
+    data class Delmal(val id: String)
 
     data class Faktagrunnlag(
         val tekniskNavn: String,
@@ -26,7 +26,7 @@ data class OppdaterBrevdataRequest(
     )
 
     data class Fritekst(
-        val id: String,
+        val parentId: String,
         val key: String,
         val fritekstJson: String
     )

--- a/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/OppdaterBrevdataRequest.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/OppdaterBrevdataRequest.kt
@@ -1,32 +1,35 @@
 package no.nav.aap.brev.kontrakt
 
 data class OppdaterBrevdataRequest(
-    val delmaler: List<Delmal>,
-    val faktagrunnlag: List<FaktagrunnlagMedVerdi>,
+    val delmaler: List<ValgtDelmal>,
+    val faktagrunnlag: List<Faktagrunnlag>,
     val periodetekster: List<Periodetekst>,
     val valg: List<Valg>,
     val betingetTekst: List<BetingetTekst>,
-    val fritekster: List<FritekstMedKey>
+    val fritekster: List<Fritekst>
 ) {
-    data class Delmal(val id: String)
+    data class ValgtDelmal(val id: String)
 
-    data class FaktagrunnlagMedVerdi(
+    data class Faktagrunnlag(
         val tekniskNavn: String,
         val verdi: String
     )
 
     data class Periodetekst(
         val id: String,
-        val faktagrunnlagMedVerdi: List<FaktagrunnlagMedVerdi>
+        val faktagrunnlag: List<Faktagrunnlag>
     )
 
     data class Valg(
         val id: String,
-        val valgt: String, // key
-        val fritekstJson: String?,
+        val key: String,
     )
 
-    data class FritekstMedKey(val key: String, val fritekstJson: String)
+    data class Fritekst(
+        val id: String,
+        val key: String,
+        val fritekstJson: String
+    )
 
     data class BetingetTekst(val id: String)
 }

--- a/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/OppdaterBrevdataRequest.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/OppdaterBrevdataRequest.kt
@@ -28,7 +28,7 @@ data class OppdaterBrevdataRequest(
     data class Fritekst(
         val parentId: String,
         val key: String,
-        val fritekstJson: String
+        val fritekst: String
     )
 
     data class BetingetTekst(val id: String)


### PR DESCRIPTION
Lagrer fritekst flatt, kan være for en delmal eller et valg. Fjerner derfor fritekst fra valg-datatypen.