### PR TITLE
Bump testcontainters version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,12 +67,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersjon")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersjon")
     testImplementation("org.assertj:assertj-core:3.27.6")
-    testImplementation("org.testcontainers:postgresql:1.21.3")
-    constraints {
-        implementation("org.apache.commons:commons-compress:1.28.0") {
-            because("https://github.com/advisories/GHSA-4g9r-vxhx-9pgx")
-        }
-    }
+    testImplementation("org.testcontainers:testcontainers-postgresql:2.0.1")
+
     testImplementation(project(":lib-test"))
     testImplementation("io.mockk:mockk:1.14.6")
 }


### PR DESCRIPTION
to remain compatible with current docker version in brew on arm64, e.g. M4 macbooks