### PR TITLE
Nytt endepunkt for å oppdatere brevmal

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/api/BestillingApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/api/BestillingApi.kt
@@ -14,6 +14,7 @@ import no.nav.aap.brev.bestilling.Saksnummer
 import no.nav.aap.brev.bestilling.UnikReferanse
 import no.nav.aap.brev.bestilling.Vedlegg
 import no.nav.aap.brev.bestilling.tilSorterbareSignaturer
+import no.nav.aap.brev.innhold.BrevinnholdService
 import no.nav.aap.brev.journalføring.DokumentInfoId
 import no.nav.aap.brev.journalføring.JournalpostId
 import no.nav.aap.brev.journalføring.SignaturService
@@ -26,6 +27,7 @@ import no.nav.aap.brev.kontrakt.FerdigstillBrevRequest
 import no.nav.aap.brev.kontrakt.ForhandsvisBrevRequest
 import no.nav.aap.brev.kontrakt.HentSignaturerRequest
 import no.nav.aap.brev.kontrakt.HentSignaturerResponse
+import no.nav.aap.brev.kontrakt.OppdaterBrevmalRequest
 import no.nav.aap.brev.person.PdlGateway
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.miljo.Miljø
@@ -224,6 +226,17 @@ fun NormalOpenAPIRoute.bestillingApi(dataSource: DataSource) {
                     personinfo = personinfo
                 )
                 respond(HentSignaturerResponse(signaturer))
+            }
+        }
+        route("/oppdater-brevmal") {
+            authorizedPut<BrevbestillingReferansePathParam, Unit, OppdaterBrevmalRequest>(authorizationBodyPathConfig) { referanse, brevdata ->
+                MDC.putCloseable(MDCNøkler.BESTILLING_REFERANSE.key, referanse.referanse.toString()).use {
+                    dataSource.transaction { connection ->
+                        BrevinnholdService.konstruer(connection)
+                            .hentOgLagreBrevmal(BrevbestillingReferanse(referanse.referanse))
+                    }
+                    respondWithStatus(HttpStatusCode.NoContent)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/no/nav/aap/brev/api/BestillingApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/api/BestillingApi.kt
@@ -229,11 +229,11 @@ fun NormalOpenAPIRoute.bestillingApi(dataSource: DataSource) {
             }
         }
         route("/oppdater-brevmal") {
-            authorizedPut<BrevbestillingReferansePathParam, Unit, OppdaterBrevmalRequest>(authorizationBodyPathConfig) { referanse, brevdata ->
-                MDC.putCloseable(MDCNøkler.BESTILLING_REFERANSE.key, referanse.referanse.toString()).use {
+            authorizedPut<Unit, String, OppdaterBrevmalRequest>(authorizationBodyPathConfig) { _, request ->
+                MDC.putCloseable(MDCNøkler.BESTILLING_REFERANSE.key, request.referanse.toString()).use {
                     dataSource.transaction { connection ->
                         BrevinnholdService.konstruer(connection)
-                            .hentOgLagreBrevmal(BrevbestillingReferanse(referanse.referanse))
+                            .hentOgLagreBrevmal(BrevbestillingReferanse(request.referanse))
                     }
                     respondWithStatus(HttpStatusCode.NoContent)
                 }

--- a/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/OppdaterBrevmalRequest.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/brev/kontrakt/OppdaterBrevmalRequest.kt
@@ -1,0 +1,5 @@
+package no.nav.aap.brev.kontrakt
+
+import java.util.UUID
+
+data class OppdaterBrevmalRequest(val referanse: UUID)


### PR DESCRIPTION
Brevmal blir i utgangspunktet hentet og lagret en gang. Nytt endepunkt gjør det mulig å oppdatere/"nullstille" brevmalen. Relevant f.eks. dersom det er gjort endringer på malen. Brevdata (bruker- og maskin-input) påvirkes ikke.