### PR TITLE
AccessPolicy-regelen er ikke i bruk fra koden og fjernes

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -86,7 +86,6 @@ spec:
         - host: saf-q2.dev-fss-pub.nais.io
         - host: pdl-api.dev-fss-pub.nais.io
       rules:
-        - application: behandlingsflyt
         - application: brev-sanity-proxy
         - application: saksbehandling-pdfgen
         - application: nom-api

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -75,7 +75,6 @@ spec:
         - host: saf.prod-fss-pub.nais.io
         - host: pdl-api.prod-fss-pub.nais.io
       rules:
-        - application: behandlingsflyt
         - application: brev-sanity-proxy
         - application: saksbehandling-pdfgen
         - application: nom-api


### PR DESCRIPTION
Koden til `brev` avhenger ikke av behandlingsflyt. Likevel deklarerer NAIS-manifestet til aap-brev at appen både sender og mottar trafikk fra behandlingsflyt. 
Denne PR fjerner derfor utgående tilgang til behandlingsflyt fra brev. 

Må dobbeltsjekkes av noen som er "in the know". Kan det være noe med at brev _indirekte_ sender requester til behandlingsflyt-api, gjennom kode den bruker som ligger utenfor brev?