### PR TITLE
AAP-1819 Forvaltningsmeldinger må gå til print

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/distribusjon/DokdistfordelingGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/distribusjon/DokdistfordelingGateway.kt
@@ -64,13 +64,13 @@ class DokdistfordelingGateway : DistribusjonGateway {
                 -> Distribusjonstype.VEDTAK
 
             Brevtype.FORHÅNDSVARSEL_BRUDD_AKTIVITETSPLIKT,
-            Brevtype.FORHÅNDSVARSEL_KLAGE_FORMKRAV
+            Brevtype.FORHÅNDSVARSEL_KLAGE_FORMKRAV,
+            Brevtype.FORVALTNINGSMELDING,
                 -> Distribusjonstype.VIKTIG
 
             Brevtype.KLAGE_MOTTATT,
             Brevtype.KLAGE_TRUKKET,
             Brevtype.VARSEL_OM_BESTILLING,
-            Brevtype.FORVALTNINGSMELDING,
             Brevtype.KLAGE_OPPRETTHOLDELSE
                 -> Distribusjonstype.ANNET
         }


### PR DESCRIPTION
Dersom bruker er digital, men ikke har digital postkasse vil det å sette distribusjonstype VIKTIG sørge for at brev blir sendt pr post hvis det ikke blir åpnet på nav.no.