### PR TITLE
Tillat at navn og adresse ikke spesifiseres for norsk orgnr

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/bestilling/MottakerRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/bestilling/MottakerRepository.kt
@@ -78,14 +78,14 @@ data class Mottaker(
     val bestillingMottakerReferanse: String,
 ) {
     init {
-        require(navnOgAdresse != null || identType == IdentType.FNR) {
-            "navnOgAdresse må være satt dersom identType ikke er FNR."
+        require(navnOgAdresse != null || identType == IdentType.FNR || identType == IdentType.ORGNR) {
+            "navnOgAdresse må være satt dersom identType ikke er FNR eller ORGNR."
         }
         require(
             (identType != null && ident != null)
                     || (identType == null && ident == null)
         ) {
-            "idenType og ident må være satt sammen, eller begge må være null"
+            "identType og ident må være satt sammen, eller begge må være null."
         }
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/brev/journalføring/JournalføringData.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/journalføring/JournalføringData.kt
@@ -19,14 +19,14 @@ data class JournalføringData(
     }
 
     init {
-        require(mottakerNavn != null || mottakerType == MottakerType.FNR) {
-            "MottakerNavn må være satt dersom MottakerType ikke er FNR."
+        require(mottakerNavn != null || mottakerType == MottakerType.FNR || mottakerType == MottakerType.ORGNR) {
+            "mottakerNavn må være satt dersom mottakerType ikke er FNR eller ORGNR."
         }
         require(
             (mottakerType != null && mottakerIdent != null)
                     || (mottakerType == null && mottakerIdent == null)
         ) {
-            "MottakerType og MottakerIdent må være satt sammen, eller begge må være null"
+            "mottakerType og mottakerIdent må være satt sammen, eller begge må være null."
         }
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/brev/journalføring/OpprettJournalpostRequest.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/journalføring/OpprettJournalpostRequest.kt
@@ -20,14 +20,14 @@ data class OpprettJournalpostRequest(
         val navn: String? = null
     ) {
         init {
-            require(navn != null || idType == IdType.FNR) {
-                "MottakerNavn må være satt dersom MottakerType ikke er FNR."
+            require(navn != null || idType == IdType.FNR || idType == IdType.ORGNR) {
+                "navn må være satt dersom idType ikke er FNR eller ORGNR."
             }
             require(
                 (idType != null && id != null)
                         || (idType == null && id == null)
             ) {
-                "IdType og id må være satt sammen, eller begge må være null"
+                "idType og id må være satt sammen, eller begge må være null"
             }
         }
 


### PR DESCRIPTION
Navn og adresse for norsk orgnr slås opp automatisk av tjenestene for journalføring og distribusjon