### PR TITLE
Hent forrige OrgTilknytning til ansatt dersom ingen aktiv

### DIFF
--- a/app/src/test/kotlin/no/nav/aap/brev/organisasjon/NomInfoGatewayTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/organisasjon/NomInfoGatewayTest.kt
@@ -1,0 +1,144 @@
+package no.nav.aap.brev.organisasjon
+
+import no.nav.aap.brev.no.nav.aap.brev.test.Fakes
+import no.nav.aap.brev.test.fakes.nomDataForNavIdent
+import no.nav.aap.brev.test.randomNavIdent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class NomInfoGatewayTest {
+
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun beforeAll() {
+            Fakes.start()
+        }
+    }
+
+    @Test
+    fun `bruker enhet for gjeldende OrgTilknytning med daglig oppfølging`() {
+        val navIdent = randomNavIdent()
+        nomDataForNavIdent(
+            navIdent, NomData(
+                NomDataRessurs(
+                    orgTilknytning = listOf(
+                        OrgTilknytning(
+                            orgEnhet = OrgEnhet("1234"),
+                            erDagligOppfolging = true,
+                            gyldigFom = LocalDate.now().minusDays(61),
+                            gyldigTom = LocalDate.now().minusDays(31)
+                        ),
+                        OrgTilknytning(
+                            orgEnhet = OrgEnhet("2345"),
+                            erDagligOppfolging = true,
+                            gyldigFom = LocalDate.now().minusDays(30),
+                            gyldigTom = LocalDate.now().minusDays(1)
+                        ),
+                        OrgTilknytning(
+                            orgEnhet = OrgEnhet("3456"),
+                            erDagligOppfolging = true,
+                            gyldigFom = LocalDate.now(),
+                            gyldigTom = null
+                        ),
+                        OrgTilknytning(
+                            orgEnhet = OrgEnhet("4567"),
+                            erDagligOppfolging = false,
+                            gyldigFom = LocalDate.now(),
+                            gyldigTom = null
+                        )
+                    ), visningsnavn = "Saksbehandler Navn"
+                )
+            )
+        )
+
+        val ansattInfo = NomInfoGateway().hentAnsattInfo(navIdent)
+
+        assertThat(ansattInfo.navIdent).isEqualTo(navIdent)
+        assertThat(ansattInfo.navn).isEqualTo("Saksbehandler Navn")
+        assertThat(ansattInfo.enhetsnummer).isEqualTo("3456")
+    }
+
+    @Test
+    fun `bruker enhet fra siste OrgTilknytning med daglig oppfølging dersom det ikke finnes en som er gyldig nå`() {
+        val navIdent = randomNavIdent()
+        nomDataForNavIdent(
+            navIdent, NomData(
+                NomDataRessurs(
+                    orgTilknytning = listOf(
+                        OrgTilknytning(
+                            orgEnhet = OrgEnhet("1234"),
+                            erDagligOppfolging = true,
+                            gyldigFom = LocalDate.now().minusDays(61),
+                            gyldigTom = LocalDate.now().minusDays(31)
+                        ),
+                        OrgTilknytning(
+                            orgEnhet = OrgEnhet("2345"),
+                            erDagligOppfolging = true,
+                            gyldigFom = LocalDate.now().minusDays(30),
+                            gyldigTom = LocalDate.now().minusDays(1)
+                        ),
+                    ), visningsnavn = "Saksbehandler Navn"
+                )
+            )
+        )
+
+        val ansattInfo = NomInfoGateway().hentAnsattInfo(navIdent)
+
+        assertThat(ansattInfo.navIdent).isEqualTo(navIdent)
+        assertThat(ansattInfo.navn).isEqualTo("Saksbehandler Navn")
+        assertThat(ansattInfo.enhetsnummer).isEqualTo("2345")
+    }
+
+    @Test
+    fun `feiler dersom det ikke finnes en OrgTilknytning daglig oppfølging`() {
+        val navIdent = randomNavIdent()
+        nomDataForNavIdent(
+            navIdent, NomData(
+                NomDataRessurs(
+                    orgTilknytning = listOf(
+                        OrgTilknytning(
+                            orgEnhet = OrgEnhet("4567"),
+                            erDagligOppfolging = false,
+                            gyldigFom = LocalDate.now(),
+                            gyldigTom = null
+                        )
+                    ), visningsnavn = "Saksbehandler Navn"
+                )
+            )
+        )
+
+        val exception = assertThrows<IllegalStateException> {
+            NomInfoGateway().hentAnsattInfo(navIdent)
+        }
+        assertThat(exception.message)
+            .isEqualTo("Fant ikke OrgTilknytning for ansatt. Klarer ikke utlede enhet for signatur.")
+    }
+
+    @Test
+    fun `feiler dersom valgt OrgTilknytning mangler enhet ID fra Remedy`() {
+        val navIdent = randomNavIdent()
+        nomDataForNavIdent(
+            navIdent, NomData(
+                NomDataRessurs(
+                    orgTilknytning = listOf(
+                        OrgTilknytning(
+                            orgEnhet = OrgEnhet(remedyEnhetId = null),
+                            erDagligOppfolging = true,
+                            gyldigFom = LocalDate.now(),
+                            gyldigTom = null
+                        )
+                    ), visningsnavn = "Saksbehandler Navn"
+                )
+            )
+        )
+        val exception = assertThrows<IllegalStateException> {
+            NomInfoGateway().hentAnsattInfo(navIdent)
+        }
+        assertThat(exception.message)
+            .isEqualTo("Klarer ikke utlede enhet for signatur. OrgEnhet til OrgTilknytning mangler RemedyEnhetId.")
+    }
+}

--- a/lib-test/src/main/kotlin/no/nav/aap/brev/test/fakes/NomFake.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/brev/test/fakes/NomFake.kt
@@ -1,33 +1,29 @@
 package no.nav.aap.brev.test.fakes
 
-import io.ktor.server.application.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
+import io.ktor.server.application.Application
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
 import no.nav.aap.brev.organisasjon.NomData
-import no.nav.aap.brev.organisasjon.NomDataRessurs
-import no.nav.aap.brev.organisasjon.OrgEnhet
-import no.nav.aap.brev.organisasjon.OrgTilknytning
+import no.nav.aap.brev.organisasjon.NomRessursVariables
 import no.nav.aap.brev.util.graphql.GraphQLResponse
-import java.time.LocalDate
+import no.nav.aap.brev.util.graphql.GraphqlRequest
+import no.nav.aap.komponenter.json.DefaultJsonMapper
+
+private val navIdentTilNomData = mutableMapOf<String, NomData>()
+
+fun nomDataForNavIdent(navIdent: String, nomData: NomData) {
+    navIdentTilNomData.put(navIdent, nomData)
+}
 
 fun Application.nomFake() {
     applicationFakeFelles("nom")
     routing {
         post("/graphql") {
-            val data = NomData(
-                NomDataRessurs(
-                    orgTilknytning = listOf(
-                        OrgTilknytning(
-                            OrgEnhet("1234"),
-                            true,
-                            LocalDate.now(),
-                            null
-                        )
-                    ), visningsnavn = "Test"
-                )
-            )
+            val request = DefaultJsonMapper.fromJson<GraphqlRequest<NomRessursVariables>>(call.receiveText())
             val response = GraphQLResponse(
-                data,
+                navIdentTilNomData[request.variables.navIdent],
                 emptyList()
             )
 


### PR DESCRIPTION
Enhet for ansatt i signatur feilet dersom det ikke er er en aktiv OrgTilknytning med daglig oppfølging. Dette kan skje siden saksbehandling kan skje en stund før brevet skal sendes.