### PR TITLE
Valider at faktagrunnlag i brevdata ikke oppdateres

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/bestilling/BrevbestillingService.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/bestilling/BrevbestillingService.kt
@@ -219,7 +219,7 @@ class BrevbestillingService(
 
     fun oppdaterBrevdata(referanse: BrevbestillingReferanse, brevdata: Brevdata) {
         val bestilling = brevbestillingRepository.hent(referanse)
-        validerOppdaterBrevdata(bestilling)
+        validerOppdaterBrevdata(bestilling, brevdata)
         brevbestillingRepository.oppdaterBrevdata(bestilling.id, brevdata)
     }
 
@@ -375,9 +375,21 @@ class BrevbestillingService(
         }
     }
 
-    private fun validerOppdaterBrevdata(bestilling: Brevbestilling) {
+    private fun validerOppdaterBrevdata(
+        bestilling: Brevbestilling,
+        nyBrevdata: Brevdata
+    ) {
         valider(bestilling.status == Status.UNDER_ARBEID) {
             "Forsøkte å oppdatere brev i bestilling med status=${bestilling.status}"
+        }
+        val eksisterendeFaktagrunnlag = bestilling.brevdata?.faktagrunnlag ?: emptyList()
+        val nyFaktagrunnlag = nyBrevdata.faktagrunnlag
+
+        valider(
+            nyFaktagrunnlag.containsAll(eksisterendeFaktagrunnlag) &&
+                    nyFaktagrunnlag.size == eksisterendeFaktagrunnlag.size
+        ) {
+            "Kan ikke oppdatere faktagrunnlag"
         }
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/brev/IntegrationTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/IntegrationTest.kt
@@ -5,6 +5,7 @@ import no.nav.aap.brev.bestilling.BrevbestillingId
 import no.nav.aap.brev.bestilling.BrevbestillingReferanse
 import no.nav.aap.brev.bestilling.BrevbestillingRepositoryImpl
 import no.nav.aap.brev.bestilling.BrevbestillingService
+import no.nav.aap.brev.bestilling.Brevdata
 import no.nav.aap.brev.bestilling.OpprettBrevbestillingResultat
 import no.nav.aap.brev.bestilling.Saksnummer
 import no.nav.aap.brev.bestilling.UnikReferanse
@@ -96,6 +97,13 @@ abstract class IntegrationTest {
         dataSource.transaction { connection ->
             val brevbestillingService = BrevbestillingService.konstruer(connection)
             brevbestillingService.oppdaterBrev(referanse, brev)
+        }
+    }
+
+    fun oppdaterBrevdata(referanse: BrevbestillingReferanse, brevdata: Brevdata) {
+        dataSource.transaction { connection ->
+            val brevbestillingService = BrevbestillingService.konstruer(connection)
+            brevbestillingService.oppdaterBrevdata(referanse, brevdata)
         }
     }
 

--- a/app/src/test/kotlin/no/nav/aap/brev/bestilling/OppdaterBestillingValideringTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/bestilling/OppdaterBestillingValideringTest.kt
@@ -1,6 +1,7 @@
 package no.nav.aap.brev.bestilling
 
 import no.nav.aap.brev.IntegrationTest
+import no.nav.aap.brev.bestilling.Brevdata.Faktagrunnlag
 import no.nav.aap.brev.feil.ValideringsfeilException
 import no.nav.aap.brev.kontrakt.Status
 import no.nav.aap.brev.test.fakes.brev
@@ -21,6 +22,25 @@ class OppdaterBestillingValideringTest : IntegrationTest() {
         oppdaterBrev(bestilling.referanse, brev())
     }
 
+    @Test
+    fun `oppdaterer brevdata i riktig status`() {
+        val bestilling = opprettBrevbestilling(
+            brukV3 = true,
+            ferdigstillAutomatisk = false,
+        ).brevbestilling
+        assertThat(bestilling.status).isEqualTo(Status.UNDER_ARBEID)
+        oppdaterBrevdata(
+            bestilling.referanse, brevdata = Brevdata(
+                delmaler = emptyList(),
+                faktagrunnlag = emptyList(),
+                periodetekster = emptyList(),
+                valg = emptyList(),
+                betingetTekst = emptyList(),
+                fritekster = emptyList(),
+            )
+        )
+    }
+
     @ParameterizedTest
     @EnumSource(
         Status::class, mode = Mode.EXCLUDE, names = ["UNDER_ARBEID"]
@@ -37,5 +57,55 @@ class OppdaterBestillingValideringTest : IntegrationTest() {
         assertThat(exception.message).endsWith(
             "Forsøkte å oppdatere brev i bestilling med status=$status"
         )
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        Status::class, mode = Mode.EXCLUDE, names = ["UNDER_ARBEID"]
+    )
+    fun `validering feiler ved forsøk på oppdatering av brevdata i feil status`(status: Status) {
+        val bestilling = opprettBrevbestilling(
+            brukV3 = true,
+            ferdigstillAutomatisk = false,
+        ).brevbestilling
+        oppdaterStatus(bestilling.id, status)
+
+        val exception = assertThrows<ValideringsfeilException> {
+            oppdaterBrevdata(
+                bestilling.referanse, brevdata = Brevdata(
+                    delmaler = emptyList(),
+                    faktagrunnlag = emptyList(),
+                    periodetekster = emptyList(),
+                    valg = emptyList(),
+                    betingetTekst = emptyList(),
+                    fritekster = emptyList(),
+                )
+            )
+        }
+        assertThat(exception.message).endsWith(
+            "Forsøkte å oppdatere brev i bestilling med status=$status"
+        )
+    }
+
+    @Test
+    fun `validering feiler ved forsøk på å oppdatere faktagrunnlag i brevdata`() {
+        val bestilling = opprettBrevbestilling(
+            brukV3 = true,
+            ferdigstillAutomatisk = false,
+        ).brevbestilling
+
+        val exception = assertThrows<ValideringsfeilException> {
+            oppdaterBrevdata(
+                bestilling.referanse, brevdata = Brevdata(
+                    delmaler = emptyList(),
+                    faktagrunnlag = listOf(Faktagrunnlag("tekniskNavn", "verdi")),
+                    periodetekster = emptyList(),
+                    valg = emptyList(),
+                    betingetTekst = emptyList(),
+                    fritekster = emptyList(),
+                )
+            )
+        }
+        assertThat(exception.message).isEqualTo("Kan ikke oppdatere faktagrunnlag")
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/brev/journalføring/JournalføringServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/journalføring/JournalføringServiceTest.kt
@@ -66,23 +66,7 @@ class JournalføringServiceTest : IntegrationTest() {
                 ),
                 bestillingMottakerReferanse = bestillingMottakerReferanse2
             )
-            if (brukV3) {
-                brevbestillingService.oppdaterBrevdata(
-                    bestilling.referanse,
-                    bestilling.brevdata!!.copy(
-                        faktagrunnlag = bestilling.brevdata.faktagrunnlag
-                            .plus(Brevdata.Faktagrunnlag("VAR_1", ""))
-                            .plus(Brevdata.Faktagrunnlag("VAR_2", "")),
-                        fritekster = bestilling.brevdata.fritekster.plus(
-                            Brevdata.Fritekst(
-                                "49d9c7a7-29db-43c6-aece-45e97314a50a",
-                                "8a3109fb503c",
-                                Brevdata.FritekstJson(DefaultJsonMapper.fromJson("""{"fritekst": "abc"}"""))
-                            )
-                        )
-                    )
-                )
-            }
+
             brevbestillingService.ferdigstill(bestilling.referanse, emptyList(), listOf(mottaker1, mottaker2))
 
             journalføringService.journalførBrevbestilling(bestilling.referanse)


### PR DESCRIPTION
Det skal per nå ikke gå an å oppdatere faktagrunnlag i brevdata. Legger i første omgang på en validering, kan senere vurdere om request ikke bør inneholde faktagrunnlag dersom det ikke blir aktuelt at det skal oppdateres.