### PR TITLE
Fjern deprecation på ValideringsfeilException

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/feil/ValideringsfeilException.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/feil/ValideringsfeilException.kt
@@ -1,7 +1,3 @@
 package no.nav.aap.brev.feil
 
-@Deprecated(
-    message = "Bruk heller en variant av ApiException (UgyldigForespørselException, Internfeil, etc.)",
-    replaceWith = ReplaceWith("no.nav.aap.komponenter.httpklient.exception.ApiException")
-)
 class ValideringsfeilException(message: String): IllegalStateException(message)


### PR DESCRIPTION
ValideringsfeilException er til bruk i domenelogikk. Kan oversettes til ApiException i StatusPages. Burde ideelt sett vært forskjellige moduler (domene, api).