### PR TITLE
Fjern spesialregel for fylkesenhet til kvalitetssikrer i signatur

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/journalføring/SignaturService.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/journalføring/SignaturService.kt
@@ -3,25 +3,19 @@ package no.nav.aap.brev.journalføring
 import no.nav.aap.brev.bestilling.Personinfo
 import no.nav.aap.brev.bestilling.SorterbarSignatur
 import no.nav.aap.brev.kontrakt.Brevtype
-import no.nav.aap.brev.kontrakt.Rolle
 import no.nav.aap.brev.kontrakt.Signatur
-import no.nav.aap.brev.organisasjon.AnsattInfo
 import no.nav.aap.brev.organisasjon.AnsattInfoDevGateway
 import no.nav.aap.brev.organisasjon.AnsattInfoGateway
 import no.nav.aap.brev.organisasjon.EnhetGateway
-import no.nav.aap.brev.organisasjon.EnhetsType
 import no.nav.aap.brev.organisasjon.NomInfoGateway
 import no.nav.aap.brev.organisasjon.NorgGateway
 import no.nav.aap.komponenter.miljo.Miljø
 import no.nav.aap.komponenter.miljo.MiljøKode
-import org.slf4j.LoggerFactory
 
 class SignaturService(
     val ansattInfoGateway: AnsattInfoGateway,
     val enhetGateway: EnhetGateway,
 ) {
-
-    private val log = LoggerFactory.getLogger(javaClass)
 
     private val NAY_AAP_ENHET = "4491"
 
@@ -39,45 +33,11 @@ class SignaturService(
         brevtype: Brevtype,
         personinfo: Personinfo
     ): List<Signatur> {
-        return if (personinfo.harStrengtFortroligAdresse || sorterbareSignaturer.isEmpty()) {
-            emptyList()
-        } else {
-            val sorterteSignaturer = sorterbareSignaturer.sortedBy { it.sorteringsnøkkel }
-
-            if (harEnhetISignatur(sorterbareSignaturer)) {
-                return signaturerV2(sorterteSignaturer, brevtype)
-            }
-
-            val ansattInfoMedRolle: List<AnsattInfoMedRolle> = sorterteSignaturer.map {
-                log.info("Henter ansatt-info for ansatt med rolle ${it.rolle}")
-                it to ansattInfoGateway.hentAnsattInfo(it.navIdent)
-            }.map { (signatur, ansattInfo) ->
-                AnsattInfoMedRolle(ansattInfo, signatur.rolle)
-            }
-
-            val enheter = enhetGateway.hentEnheter(ansattInfoMedRolle.map { it.ansattInfo.enhetsnummer })
-
-            ansattInfoMedRolle.map { ansattInfoMedRolle ->
-                val ansattEnhet = enheter.single { it.enhetsNummer == ansattInfoMedRolle.ansattInfo.enhetsnummer }
-                val valgtEnhet =
-                    if (ansattEnhet.type == EnhetsType.LOKAL && ansattInfoMedRolle.rolle == Rolle.KVALITETSSIKRER) {
-                        enhetGateway.hentOverordnetFylkesenhet(ansattEnhet.enhetsNummer)
-                    } else {
-                        ansattEnhet
-                    }
-
-                Signatur(
-                    navn = ansattInfoMedRolle.ansattInfo.navn,
-                    enhet = if (brukEnhetsTypeNavn(brevtype)) valgtEnhet.enhetstypeNavn else valgtEnhet.navn
-                )
-            }
+        if (personinfo.harStrengtFortroligAdresse || sorterbareSignaturer.isEmpty()) {
+            return emptyList()
         }
-    }
 
-    private fun signaturerV2(
-        sorterteSignaturer: List<SorterbarSignatur>,
-        brevtype: Brevtype,
-    ): List<Signatur> {
+        val sorterteSignaturer = sorterbareSignaturer.sortedBy { it.sorteringsnøkkel }
         val navIdentTilAnsattInfo = sorterteSignaturer.associate { signatur ->
             signatur.navIdent to ansattInfoGateway.hentAnsattInfo(signatur.navIdent)
         }
@@ -100,10 +60,6 @@ class SignaturService(
                 enhet = if (brukEnhetsTypeNavn(brevtype)) enhet.enhetstypeNavn else enhet.navn
             )
         }
-    }
-
-    private fun harEnhetISignatur(sorterbareSignaturer: List<SorterbarSignatur>): Boolean {
-        return sorterbareSignaturer.any { it.enhet != null }
     }
 
     private fun brukEnhetsTypeNavn(brevtype: Brevtype): Boolean {
@@ -143,6 +99,4 @@ class SignaturService(
             }
         }
     }
-
-    private data class AnsattInfoMedRolle(val ansattInfo: AnsattInfo, val rolle: Rolle?)
 }

--- a/app/src/main/kotlin/no/nav/aap/brev/organisasjon/EnhetGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/organisasjon/EnhetGateway.kt
@@ -1,8 +1,5 @@
 package no.nav.aap.brev.organisasjon
 
 interface EnhetGateway {
-
     fun hentEnheter(enhetsnummer: List<String>): List<Enhet>
-
-    fun hentOverordnetFylkesenhet(enhetsnummer: String): Enhet
 }

--- a/app/src/main/kotlin/no/nav/aap/brev/organisasjon/NorgGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/organisasjon/NorgGateway.kt
@@ -38,22 +38,6 @@ class NorgGateway : EnhetGateway {
         return response.map { it.tilEnhet() }
     }
 
-    override fun hentOverordnetFylkesenhet(enhetsnummer: String): Enhet {
-        val uri = baseUri.resolve("/norg2/api/v1/enhet/$enhetsnummer/overordnet?organiseringsType=${EnhetsType.FYLKE}")
-
-        val httpRequest = GetRequest(
-            additionalHeaders = listOf(
-                Header("Accept", "application/json")
-            )
-        )
-        val response: List<NorgEnhet> =
-            checkNotNull(client.get(uri = uri, request = httpRequest, mapper = { body, _ ->
-                DefaultJsonMapper.fromJson(body)
-            }))
-
-        return response.single().tilEnhet()
-    }
-
     private fun NorgEnhet.tilEnhet(): Enhet {
         return Enhet(
             enhetsNummer = enhetNr,

--- a/app/src/test/kotlin/no/nav/aap/brev/journalføring/SignaturServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/brev/journalføring/SignaturServiceTest.kt
@@ -15,8 +15,6 @@ import no.nav.aap.brev.organisasjon.NorgGateway
 import no.nav.aap.brev.test.randomBrukerIdent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 
 class SignaturServiceTest {
 
@@ -34,9 +32,8 @@ class SignaturServiceTest {
         assertThat(signaturer).isEmpty()
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = [true, false])
-    fun `signaturer sorteres basert på angitt sorteringsnøkkel`(harEnhetISignatur: Boolean) {
+    @Test
+    fun `signaturer sorteres basert på angitt sorteringsnøkkel`() {
 
         every { ansattInfoGateway.hentAnsattInfo("navident1") } returns AnsattInfo(
             navIdent = "navident1",
@@ -53,19 +50,13 @@ class SignaturServiceTest {
             navn = "Ansattnavn3",
             enhetsnummer = "1234",
         )
-        every { enhetGateway.hentOverordnetFylkesenhet(any()) } returns Enhet(
-            "4321",
-            "Overordnet enhet",
-            EnhetsType.FYLKE
-        )
         every { enhetGateway.hentEnheter(any()) } returns listOf(Enhet("1234", "Enhet", EnhetsType.LOKAL))
 
-        val enhet = if (harEnhetISignatur) "1234" else null
         val signaturer = signaturService.signaturer(
             listOf(
-                SorterbarSignatur("navident2", 1, null, enhet),
-                SorterbarSignatur("navident1", 0, null, enhet),
-                SorterbarSignatur("navident3", 2, null, enhet)
+                SorterbarSignatur("navident2", 1, null, "1234"),
+                SorterbarSignatur("navident1", 0, null, "1234"),
+                SorterbarSignatur("navident3", 2, null, "1234")
             ),
             Brevtype.INNVILGELSE,
             personinfo = Personinfo(
@@ -84,34 +75,7 @@ class SignaturServiceTest {
     }
 
     @Test
-    fun `kvalitetssikrer signerer med navn på overordnet fylkesenhet`() {
-
-        every { ansattInfoGateway.hentAnsattInfo(any()) } returns AnsattInfo(
-            navIdent = "navident",
-            navn = "Ansattnavn",
-            enhetsnummer = "1234",
-        )
-        every { enhetGateway.hentOverordnetFylkesenhet(any()) } returns Enhet(
-            "4321",
-            "Overordnet enhet",
-            EnhetsType.FYLKE
-        )
-        every { enhetGateway.hentEnheter(any()) } returns listOf(Enhet("1234", "Enhet", EnhetsType.LOKAL))
-
-        val signaturer = signaturService.signaturer(
-            sorterbareSignaturer = listOf(SorterbarSignatur("navident", 1, Rolle.KVALITETSSIKRER, null)),
-            brevtype = Brevtype.INNVILGELSE,
-            personinfo = Personinfo(
-                personIdent = randomBrukerIdent(),
-                navn = "navn",
-                harStrengtFortroligAdresse = false
-            )
-        )
-        assertThat(signaturer).isEqualTo(listOf(Signatur(navn = "Ansattnavn", enhet = "Overordnet enhet")))
-    }
-
-    @Test
-    fun `bruker enhet fra signatur dersom definert med unntak for NAY AAP enhet, ellers ansatt-enhet`() {
+    fun `bruker enhet fra signatur dersom definert, med fallback til ansatt-enhet dersom enhet mangler eller er NAY AAP`() {
         every { ansattInfoGateway.hentAnsattInfo("navident1") } returns AnsattInfo(
             navIdent = "navident1",
             navn = "Ansattnavn1",


### PR DESCRIPTION
Ansvar for denne logikken er flyttet til konsument ved å sende enhet i signatur-grunnlaget. Konsument (behandlingsflyt) sender nå med enhet i signatur-grunnlaget basert på hvilke enhet oppgaver har (fra oppgave-appen).