### PR TITLE
Egen ktor group i dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,22 @@ updates:
           applies-to: version-updates
           exclude-patterns:
             - "no.nav.aap*"
+            - "io.ktor:ktor-*"
+            - "io.ktor.plugin"
+            - "gradle-wrapper"
+          update-types:
+            - "minor"
+            - "patch"
+        gradle:
+          patterns:
+            - "gradle-wrapper"
+          update-types:
+            - "minor"
+            - "patch"
+        ktor:
+          patterns:
+            - "io.ktor:ktor-*"
+            - "io.ktor.plugin"
           update-types:
             - "minor"
             - "patch"


### PR DESCRIPTION
Skiller ut ktor oppdateringer i egne PRs så det blir lettere å holde andre dependencies oppdatert