### PR TITLE
fix(ci): prevent deploy cancellations when merging concurrent PRs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,9 @@ jobs:
 
   publiser-kontrakt:
     needs: build
+    concurrency:
+      group: publiser-kontrakt
+      queue: max
     permissions:
       contents: write
       packages: write
@@ -80,7 +83,9 @@ jobs:
       contents: read
       id-token: write
     uses: navikt/aap-workflows/.github/workflows/deploy.yml@main
-    concurrency: deploy-dev
+    concurrency:
+      group: deploy-dev
+      queue: max
     secrets: inherit
     with:
       cluster: dev-gcp
@@ -92,7 +97,9 @@ jobs:
       contents: read
       id-token: write
     uses: navikt/aap-workflows/.github/workflows/deploy.yml@main
-    concurrency: deploy-prod
+    concurrency:
+      group: deploy-prod
+      queue: max
     secrets: inherit
     with:
       cluster: prod-gcp


### PR DESCRIPTION
## Problem
When merging several dependabot PRs in quick succession, one of the deploys often fails.

Job-level `concurrency` groups (e.g. `deploy-dev`, `deploy-prod`) used the default `queue: single` behavior, which **cancels a pending run** whenever a newer run is queued in the same group. Each new merge queues a new deploy and cancels the previous one's still-pending deploy job \u2014 showing up as a failed/cancelled deploy.

## Fix
- Add `queue: max` to the `deploy-dev`/`deploy-prod` concurrency groups so queued deploys run sequentially (FIFO) instead of cancelling each other.
- Add/strengthen concurrency groups on kontrakt-publishing jobs to avoid racing semantic-version tag computation across concurrent runs.

`queue: max` requires `cancel-in-progress: false` (the default), which these jobs already use.

Companion PR: https://github.com/navikt/aap-utbetal/pull/596