### PR TITLE
AAP-2194 Håndter at journalpost allerede er ekspedert

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/brev/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/App.kt
@@ -19,6 +19,10 @@ import no.nav.aap.brev.api.bestillingApi
 import no.nav.aap.brev.api.distribusjonApi
 import no.nav.aap.brev.api.dokumentinnhentingApi
 import no.nav.aap.brev.api.driftApi
+import no.nav.aap.brev.arkivoppslag.SafGateway
+import no.nav.aap.brev.bestilling.SaksbehandlingPdfGenGateway
+import no.nav.aap.brev.journalføring.DokarkivGateway
+import no.nav.aap.brev.person.PdlGateway
 import no.nav.aap.brev.prosessering.ProsesserBrevbestillingJobbUtfører
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbmigrering.Migrering
@@ -74,12 +78,17 @@ internal fun Application.server(dbConfig: DbConfig) {
 
     val motor = module(dataSource)
     val påkrevdeRollerMotor = if (Miljø.erProd()) listOf(TeamAap.id) else emptyList()
-    
+
+    val personinfoGateway = PdlGateway()
+    val pdfGateway = SaksbehandlingPdfGenGateway()
+    val arkivGateway = DokarkivGateway()
+    val safGateway = SafGateway()
+
     routing {
         authenticate(IdentityProvider.ENTRA_ID.value) {
             apiRouting {
-                bestillingApi(dataSource)
-                dokumentinnhentingApi()
+                bestillingApi(dataSource, personinfoGateway)
+                dokumentinnhentingApi(pdfGateway, arkivGateway, safGateway)
                 distribusjonApi(dataSource)
                 motorApi(dataSource, påkrevdeRollerMotor)
                 driftApi(dataSource)

--- a/app/src/main/kotlin/no/nav/aap/brev/api/BestillingApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/api/BestillingApi.kt
@@ -10,6 +10,7 @@ import no.nav.aap.brev.bestilling.BehandlingReferanse
 import no.nav.aap.brev.bestilling.BrevbestillingReferanse
 import no.nav.aap.brev.bestilling.BrevbestillingService
 import no.nav.aap.brev.bestilling.PdfService
+import no.nav.aap.brev.bestilling.PersoninfoGateway
 import no.nav.aap.brev.bestilling.Saksnummer
 import no.nav.aap.brev.bestilling.UnikReferanse
 import no.nav.aap.brev.bestilling.Vedlegg
@@ -29,7 +30,6 @@ import no.nav.aap.brev.kontrakt.GjenopptaBrevbestillingRequest
 import no.nav.aap.brev.kontrakt.HentSignaturerRequest
 import no.nav.aap.brev.kontrakt.HentSignaturerResponse
 import no.nav.aap.brev.kontrakt.OppdaterBrevmalRequest
-import no.nav.aap.brev.person.PdlGateway
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.miljo.Miljø
 import no.nav.aap.tilgang.AuthorizationBodyPathConfig
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import javax.sql.DataSource
 
-fun NormalOpenAPIRoute.bestillingApi(dataSource: DataSource) {
+fun NormalOpenAPIRoute.bestillingApi(dataSource: DataSource, personinfoGateway: PersoninfoGateway) {
     val logger = LoggerFactory.getLogger(this::class.java)
     val authorizationBodyPathConfig = AuthorizationBodyPathConfig(
         operasjon = Operasjon.SAKSBEHANDLE,
@@ -240,7 +240,6 @@ fun NormalOpenAPIRoute.bestillingApi(dataSource: DataSource) {
         }
         route("/forhandsvis-signaturer") {
             authorizedPost<Unit, HentSignaturerResponse, HentSignaturerRequest>(authorizationBodyPathConfig) { _, request ->
-                val personinfoGateway = PdlGateway()
                 val personinfo = personinfoGateway.hentPersoninfo(request.brukerIdent)
                 val signaturService = SignaturService.konstruer()
                 val signaturer = signaturService.signaturer(

--- a/app/src/main/kotlin/no/nav/aap/brev/api/DokumentinnhentingApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/api/DokumentinnhentingApi.kt
@@ -5,6 +5,7 @@ import com.papsign.ktor.openapigen.route.response.respond
 import com.papsign.ktor.openapigen.route.response.respondWithStatus
 import com.papsign.ktor.openapigen.route.route
 import io.ktor.http.*
+import no.nav.aap.brev.arkivoppslag.ArkivoppslagGateway
 import no.nav.aap.brev.bestilling.PdfBrev
 import no.nav.aap.brev.bestilling.PdfBrev.Blokk
 import no.nav.aap.brev.bestilling.PdfBrev.FormattertTekst
@@ -12,11 +13,12 @@ import no.nav.aap.brev.bestilling.PdfBrev.Innhold
 import no.nav.aap.brev.bestilling.PdfBrev.Mottaker
 import no.nav.aap.brev.bestilling.PdfBrev.Mottaker.IdentType
 import no.nav.aap.brev.bestilling.PdfBrev.Tekstbolk
-import no.nav.aap.brev.bestilling.SaksbehandlingPdfGenGateway
+import no.nav.aap.brev.bestilling.PdfGateway
 import no.nav.aap.brev.bestilling.Saksnummer
-import no.nav.aap.brev.journalføring.DokarkivGateway
 import no.nav.aap.brev.journalføring.JournalføringData
 import no.nav.aap.brev.journalføring.JournalføringData.MottakerType
+import no.nav.aap.brev.journalføring.JournalføringGateway
+import no.nav.aap.brev.journalføring.JournalpostId
 import no.nav.aap.brev.kontrakt.BlokkType
 import no.nav.aap.brev.kontrakt.EkspederBehandlerBestillingRequest
 import no.nav.aap.brev.kontrakt.HentSignaturDokumentinnhentingRequest
@@ -30,13 +32,21 @@ import no.nav.aap.brev.organisasjon.NomInfoGateway
 import no.nav.aap.brev.organisasjon.NorgGateway
 import no.nav.aap.brev.person.PdlGateway
 import no.nav.aap.brev.util.TimeUtils.formaterFullLengde
+import no.nav.aap.komponenter.httpklient.httpclient.error.BadRequestHttpResponsException
 import no.nav.aap.komponenter.miljo.Miljø
 import no.nav.aap.komponenter.miljo.MiljøKode
 import no.nav.aap.tilgang.AuthorizationBodyPathConfig
 import no.nav.aap.tilgang.Operasjon
 import no.nav.aap.tilgang.authorizedPost
+import org.slf4j.LoggerFactory
 
-fun NormalOpenAPIRoute.dokumentinnhentingApi() {
+fun NormalOpenAPIRoute.dokumentinnhentingApi(
+    pdfGateway: PdfGateway,
+    journalføringGateway: JournalføringGateway,
+    arkivoppslagGateway: ArkivoppslagGateway,
+) {
+
+    val log = LoggerFactory.getLogger(this::class.java)
 
     val authorizationBodyPathConfig = AuthorizationBodyPathConfig(
         operasjon = Operasjon.SAKSBEHANDLE,
@@ -50,14 +60,11 @@ fun NormalOpenAPIRoute.dokumentinnhentingApi() {
                 authorizationBodyPathConfig
             ) { _, request ->
 
-                val pdfGateway = SaksbehandlingPdfGenGateway()
-                val arkivGateway = DokarkivGateway()
-
                 val signatur = utledSignatur(brukerFnr = request.brukerFnr, navIdent = request.bestillerNavIdent)
 
                 val pdfBrev = mapPdfBrev(request, signatur?.let { listOf(it) } ?: emptyList())
                 val pdf = pdfGateway.genererPdf(pdfBrev)
-                val journalpostResponse = arkivGateway.journalførBrev(
+                val journalpostResponse = journalføringGateway.journalførBrev(
                     journalføringData = JournalføringData(
                         brukerFnr = request.brukerFnr,
                         mottakerIdent = request.mottakerHprnr,
@@ -87,9 +94,16 @@ fun NormalOpenAPIRoute.dokumentinnhentingApi() {
             authorizedPost<Unit, String, EkspederBehandlerBestillingRequest>(
                 authorizationBodyPathConfig
             ) { _, request ->
-                val arkivGateway = DokarkivGateway()
-
-                arkivGateway.ekspediterJournalpost(request.journalpostId, "HELSENETTET")
+                try {
+                    journalføringGateway.ekspediterJournalpost(request.journalpostId, "HELSENETTET")
+                } catch (e: BadRequestHttpResponsException) {
+                    val journalpost = arkivoppslagGateway.hentJournalpost(JournalpostId(request.journalpostId))
+                    if (journalpost.journalstatus == "EKSPEDERT") {
+                        log.info("Journalpost ${request.journalpostId} er allerede ekspedert.")
+                    } else {
+                        throw e
+                    }
+                }
 
                 respond("{}", HttpStatusCode.OK)
             }

--- a/app/src/main/kotlin/no/nav/aap/brev/journalføring/DokarkivGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/brev/journalføring/DokarkivGateway.kt
@@ -30,7 +30,7 @@ class DokarkivGateway : JournalføringGateway {
     private val log = LoggerFactory.getLogger(DokarkivGateway::class.java)
 
     private val baseUri = URI.create(requiredConfigForKey("integrasjon.dokarkiv.url"))
-    val config = ClientConfig(scope = requiredConfigForKey("integrasjon.dokarkiv.scope"))
+    private val config = ClientConfig(scope = requiredConfigForKey("integrasjon.dokarkiv.scope"))
     private val client = RestClient(
         config = config,
         tokenProvider = AzureM2MTokenProvider,


### PR DESCRIPTION
Vi får bad request i respons hvis vi forsøker å sette status ekspedert på en journalpost som allerede er ekspedert. Feilen oppstod pga en timeout, men kallet gikk igjennom.

Gjenbruker i tillegg gateways som ble opprettet direkte i routes (ikke via services).